### PR TITLE
Add a bash wrapper for running inside of Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ FROM alpine:latest
 
 RUN apk --update add ca-certificates
 
+COPY /run.sh /usr/bin/run.sh
 COPY --from=builder /go/src/github.com/mdmdirector/mdmdirector/build/linux/mdmdirector-v0.0.1 /usr/bin/mdmdirector
 
 EXPOSE 8000
-CMD ["mdmdirector"]
+CMD ["run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# The following is a bash wrapper to use ENV vs Flags.
+
+# Set Environmental VARS.
+# Postgress DB Connection requirements
+DB_PORT="${DB_PORT:-5432}"
+DB_NAME="${DB_NAME:-postgress}"
+DB_PASSWORD="${DB_PASSWORD:-password}"
+DB_SSL="${DB_SSL:-disable}"
+DB_HOST="${DB_HOST:-127.0.0.1}"
+DB_USER="${DB_USER:-postgres}"
+
+# MicroMDM Requred info
+MICRO_API_KEY="${MICRO_API_KEY}"
+MICRO_URL="${MICRO_URL}"
+
+#DirectorSetup
+DIRECTOR_PASSWORD="${DIRECTOR_PASSWORD}"
+DIRECTOR_PORT="${DIRECTOR_PORT:-8000}"
+
+# Codesigning
+SIGNING_CERT="${SIGNING_CERT}"
+SIGNING_KEY="${SIGNING_KEY}"
+SIGNING_PASSWORD="${SIGNING_PASSWORD}"
+SIGN="${SIGN}"
+
+DEBUG="${DEBUG}"
+
+runMDMDDirector="/usr/bin/mdmdirector \
+  -dbconnection host='${DB_HOST}' port='${DB_PORT}' user='${DB_USER}' dbname='${DB_NAME}' password='${DB_PASSWORD}' sslmode='${DB_SSL}' \
+  -micromdmapikey '${MICRO_API_KEY}' \
+  -micromdmurl '${MICRO_URL}' \
+  -password '${DIRECTOR_PASSWORD}' \
+  -port '${DIRECTOR_PORT}'"
+
+# Process Codesigning
+if [[ ${SIGN} ]]; then
+  if [[ ${SIGNING_CERT} ]] && [[ ${SIGNING_KEY} ]]; then
+    runMicroMDM="${runMicroMDM} \
+      -cert '${SIGNING_CERT}' \
+      -private-key '${SIGNING_KEY}' \
+      -sign"
+  elif [[ ${SIGNING_CERT} ]] && [[ ${SIGNING_PASSWORD} ]]; then
+    runMicroMDM="${runMicroMDM} \
+      -cert '${SIGNING_CERT}' \
+      -key-password  '${SIGNING_PASSWORD}' \
+      -sign"
+  fi
+fi
+
+# process debugging
+if [[ ${DEBUG} ]]; then
+  runMDMDDirector="${runMDMDDirector} \
+    -debug"
+fi
+echo $runMDMDDirector
+eval "${runMDMDDirector}"


### PR DESCRIPTION
The following is a wrapper which lines up the following wiki page. https://github.com/mdmdirector/mdmdirector/wiki/Kubernetes-deployment

This should really just be supported in Go but I "Thought" this would have been quicker.

