### PR TITLE
Remove version name from build artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM alpine:latest
 
 RUN apk --update add ca-certificates
 
-COPY --from=builder /go/src/github.com/mdmdirector/mdmdirector/build/linux/mdmdirector-v0.0.1 /usr/bin/mdmdirector
+COPY --from=builder /go/src/github.com/mdmdirector/mdmdirector/build/linux/mdmdirector /usr/bin/mdmdirector
 
 EXPOSE 8000
 CMD ["/usr/bin/mdmdirector"]

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build: clean .pre-build
 
 xp-build:  clean .pre-build
 	GOOS=darwin go build -o build/darwin/mdmdirector
-	GOOS=linux CGO_ENABLED=0 go build -o build/linux/mdmdirector-v0.0.7
+	GOOS=linux CGO_ENABLED=0 go build -o build/linux/mdmdirector
 
 postgres-clean:
 	rm -rf postgres


### PR DESCRIPTION
The existing Dockerfile fails to build because the mdmdirector binary's filename doesn't match the artifact built by the Makefile. This PR removes the version number from the filename since versioning can be handle by git tags. This matches micromdm's [Makefile](https://github.com/micromdm/micromdm/blob/main/Makefile) and [Dockerfile](https://github.com/micromdm/micromdm/blob/main/Dockerfile).