### PR TITLE
Check each information request individually

### DIFF
--- a/director/background_tasks.go
+++ b/director/background_tasks.go
@@ -127,7 +127,7 @@ func pushAll() error {
 
 		// If we havent had any of the info payloads back recently, add to list
 		if dbDevice.LastCertificateList.Before(sixHoursAgo) || dbDevice.LastProfileList.Before(sixHoursAgo) || dbDevice.LastSecurityInfo.Before(sixHoursAgo) || dbDevice.LastDeviceInfo.Before(sixHoursAgo) {
-			InfoLogger(LogHolder{DeviceUDID: dbDevice.UDID, DeviceSerial: dbDevice.SerialNumber, Message: "Have not recieved one of the information commands within the last six hours, adding to push list."})
+			InfoLogger(LogHolder{DeviceUDID: dbDevice.UDID, DeviceSerial: dbDevice.SerialNumber, Message: "Have not received one of the information commands within the last six hours, adding to push list."})
 			devices = append(devices, dbDevice)
 		}
 

--- a/director/background_tasks.go
+++ b/director/background_tasks.go
@@ -114,6 +114,7 @@ func pushAll() error {
 	DelaySeconds, HalfDelaySeconds := getDelay()
 
 	threeHoursAgo := time.Now().Add(-3 * time.Hour)
+	sixHoursAgo := time.Now().Add(-6 * time.Hour)
 	lastCheckinDelay := time.Now().Add(-HalfDelaySeconds * time.Second)
 
 	err := db.DB.Find(&dbDevices).Scan(&dbDevices).Error
@@ -123,6 +124,13 @@ func pushAll() error {
 
 	for i := range dbDevices {
 		dbDevice := dbDevices[i]
+
+		// If we havent had any of the info payloads back recently, add to list
+		if dbDevice.LastCertificateList.Before(sixHoursAgo) || dbDevice.LastProfileList.Before(sixHoursAgo) || dbDevice.LastSecurityInfo.Before(sixHoursAgo) || dbDevice.LastDeviceInfo.Before(sixHoursAgo) {
+			InfoLogger(LogHolder{DeviceUDID: dbDevice.UDID, DeviceSerial: dbDevice.SerialNumber, Message: "Have not recieved one of the information commands within the last six hours, adding to push list."})
+			devices = append(devices, dbDevice)
+		}
+
 		// If it's been updated within the last three hours, try to push again as it might still be online
 		if dbDevice.LastCheckedIn.After(threeHoursAgo) {
 			InfoLogger(LogHolder{DeviceUDID: dbDevice.UDID, DeviceSerial: dbDevice.SerialNumber, Message: "Checked in more than three hours ago"})

--- a/director/initial_tasks.go
+++ b/director/initial_tasks.go
@@ -77,9 +77,6 @@ func processDeviceConfigured(device types.Device) error {
 		return err
 	}
 
-	// RequestSecurityInfo(device)
-	// RequestDeviceInformation(device)
-	// RequestProfileList(device)
 	return nil
 }
 

--- a/director/security_info.go
+++ b/director/security_info.go
@@ -18,7 +18,7 @@ func RequestSecurityInfo(device types.Device) {
 	}
 }
 
-func SaveSecurityInfo(securityInfoData types.SecurityInfoData, device types.Device) {
+func SaveSecurityInfo(securityInfoData types.SecurityInfoData, device types.Device) error {
 	var securityInfo types.SecurityInfo
 	var managementStatus types.ManagementStatus
 	var firmwarePasswordStatus types.FirmwarePasswordStatus
@@ -28,16 +28,18 @@ func SaveSecurityInfo(securityInfoData types.SecurityInfoData, device types.Devi
 	InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Saving SecurityInfo"})
 	err := db.DB.Model(&device).Association("SecurityInfo").Append(&securityInfo).Error
 	if err != nil {
-		log.Error(err)
+		return err
 	}
 
 	err = db.DB.Model(&securityInfo).Association("FirmwarePasswordStatus").Append(&firmwarePasswordStatus).Error
 	if err != nil {
-		log.Error(err)
+		return err
 	}
 
 	err = db.DB.Model(&securityInfo).Association("ManagementStatus").Append(&managementStatus).Error
 	if err != nil {
-		log.Error(err)
+		return err
 	}
+
+	return nil
 }

--- a/director/webhook.go
+++ b/director/webhook.go
@@ -133,6 +133,13 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
 			}
+
+			if err == nil {
+				plErr := device.UpdateLastProfileList()
+				if plErr != nil {
+					ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: plErr.Error()})
+				}
+			}
 		}
 
 		_, ok = payloadDict["SecurityInfo"]
@@ -142,17 +149,17 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
 			}
-			SaveSecurityInfo(securityInfoData, device)
-		}
-
-		_, ok = payloadDict["DeviceInformation"]
-		if ok {
-			var securityInfoData types.SecurityInfoData
-			err = plist.Unmarshal(out.AcknowledgeEvent.RawPayload, &securityInfoData)
+			err = SaveSecurityInfo(securityInfoData, device)
 			if err != nil {
 				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
 			}
-			SaveSecurityInfo(securityInfoData, device)
+
+			if err == nil {
+				siErr := device.UpdateLastSecurityInfo()
+				if siErr != nil {
+					ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: siErr.Error()})
+				}
+			}
 		}
 
 		_, ok = payloadDict["CertificateList"]
@@ -166,9 +173,16 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
 			}
+
+			if err == nil {
+				clErr := device.UpdateLastCertificateList()
+				if clErr != nil {
+					ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: clErr.Error()})
+				}
+			}
 		}
 
-		_, ok = payloadDict["QueryResponses"]
+		_, ok = payloadDict["DeviceInformation"]
 		if ok {
 			var deviceInformationQueryResponses types.DeviceInformationQueryResponses
 			err = plist.Unmarshal(out.AcknowledgeEvent.RawPayload, &deviceInformationQueryResponses)
@@ -180,8 +194,13 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
 			}
 
+			if err == nil {
+				diErr := device.UpdateLastDeviceInfo()
+				if diErr != nil {
+					ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: diErr.Error()})
+				}
+			}
 		}
-
 	}
 }
 

--- a/types/device.go
+++ b/types/device.go
@@ -84,6 +84,10 @@ type Device struct {
 	NextPush                 time.Time
 	LastScheduledPush        time.Time
 	LastCheckedIn            time.Time
+	LastCertificateList      time.Time
+	LastProfileList          time.Time
+	LastDeviceInfo           time.Time
+	LastSecurityInfo         time.Time
 }
 
 var DeviceInformationQueries = []string{"ActiveManagedUsers", "AppAnalyticsEnabled", "AutoSetupAdminAccounts", "AvailableDeviceCapacity", "AwaitingConfiguration", "BatteryLevel", "BluetoothMAC", "BuildVersion", "CarrierSettingsVersion", "CellularTechnology", "CurrentMCC", "CurrentMNC", "DataRoamingEnabled", "DeviceCapacity", "DeviceID", "DeviceName", "DiagnosticSubmissionEnabled", "EASDeviceIdentifier", "ICCID", "IMEI", "IsActivationLockEnabled", "IsCloudBackupEnabled", "IsDeviceLocatorServiceEnabled", "IsDoNotDisturbInEffect", "IsMDMLostModeEnabled", "IsMultiUser", "IsNetworkTethered", "IsRoaming", "IsSupervised", "iTunesStoreAccountHash", "iTunesStoreAccountIsActive", "LastCloudBackupDate", "MaximumResidentUsers", "MDMOptions", "MEID", "Model", "ModelName", "ModemFirmwareVersion", "OrganizationInfo", "OSUpdateSettings", "OSVersion", "PersonalHotspotEnabled", "PhoneNumber", "ProductName", "PushToken", "SerialNumber", "ServiceSubscriptions", "SIMCarrierNetwork", "SIMMCC", "SIMMNC", "SubscriberCarrierNetwork", "SubscriberMCC", "SubscriberMNC", "SystemIntegrityProtectionEnabled", "UDID", "VoiceRoamingEnabled", "WiFiMAC", "EthernetMAC"}

--- a/types/update_last_recieved.go
+++ b/types/update_last_recieved.go
@@ -1,0 +1,47 @@
+package types
+
+import (
+	"time"
+
+	"github.com/mdmdirector/mdmdirector/db"
+)
+
+func (device *Device) UpdateLastProfileList() error {
+	now := time.Now()
+	var deviceModel Device
+	err := db.DB.Model(&deviceModel).Where("ud_id = ?", device.UDID).Updates(Device{LastProfileList: now}).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (device *Device) UpdateLastCertificateList() error {
+	now := time.Now()
+	var deviceModel Device
+	err := db.DB.Model(&deviceModel).Where("ud_id = ?", device.UDID).Updates(Device{LastCertificateList: now}).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (device *Device) UpdateLastDeviceInfo() error {
+	now := time.Now()
+	var deviceModel Device
+	err := db.DB.Model(&deviceModel).Where("ud_id = ?", device.UDID).Updates(Device{LastDeviceInfo: now}).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (device *Device) UpdateLastSecurityInfo() error {
+	now := time.Now()
+	var deviceModel Device
+	err := db.DB.Model(&deviceModel).Where("ud_id = ?", device.UDID).Updates(Device{LastSecurityInfo: now}).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
If we haven't got it for six hours, send a push.

Also cleans up some error handling, and fixing the DeviceInformation payload (I assume this was _never_ getting updated properly after enrollment.