### PR TITLE
flag to explicitly enable prometheus

### DIFF
--- a/director/background_tasks.go
+++ b/director/background_tasks.go
@@ -93,7 +93,9 @@ func pushNotNow() error {
 		}
 
 		resp.Body.Close()
-		TotalPushes.Inc()
+		if utils.Prometheus() {
+			TotalPushes.Inc()
+		}
 	}
 	return nil
 }
@@ -309,7 +311,10 @@ func pushConcurrent(client *http.Client) error {
 		}
 
 		resp.Body.Close()
-		TotalPushes.Inc()
+		if utils.Prometheus() {
+			TotalPushes.Inc()
+		}
+
 	}
 	return nil
 }

--- a/director/command.go
+++ b/director/command.go
@@ -55,12 +55,14 @@ func SendCommand(commandPayload types.CommandPayload) (types.Command, error) {
 	InfoLogger(LogHolder{Message: "Sent Command", DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, CommandRequestType: commandPayload.RequestType, CommandUUID: command.CommandUUID})
 
 	db.DB.Create(&command)
-	if commandPayload.RequestType == "InstallProfile" {
-		ProfilesPushed.Inc()
-	}
+	if utils.Prometheus() {
+		if commandPayload.RequestType == "InstallProfile" {
+			ProfilesPushed.Inc()
+		}
 
-	if commandPayload.RequestType == "InstallApplication" {
-		InstallApplicationsPushed.Inc()
+		if commandPayload.RequestType == "InstallApplication" {
+			InstallApplicationsPushed.Inc()
+		}
 	}
 
 	return command, nil

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -101,6 +101,10 @@ func SignedEnrollmentProfile() bool {
 	return flag.Lookup("enrollment-profile-signed").Value.(flag.Getter).Get().(bool)
 }
 
+func Prometheus() bool {
+	return flag.Lookup("prometheus").Value.(flag.Getter).Get().(bool)
+}
+
 // Code for testing goes down here
 // flags *can* be overwritten by using os.Args, but they cannot be parsed more than once or it results in a crash.
 // So, instead we inject an interface layer between the calling code that is swapped out during unit tests.


### PR DESCRIPTION
Looks like the goroutine for prometheus isn't as performant as we would have liked. This change adds a flag to explicitly enable it.

```
INFO[0000] Connecting to database                       

2021/02/04 09:20:59 /Users/graham_gilbert/src/Mine/mdmdirector/db/database.go:59
[8.595ms] [rows:0] CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
INFO[0000] Connected to database                        
INFO[0000] Performing DB migrations if required         

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:183
[138.788ms] [rows:-] SELECT count(*) FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND table_name = 'devices' AND table_type = 'BASE TABLE'

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:68
[2.277ms] [rows:-] SELECT CURRENT_DATABASE()

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:287
[78.314ms] [rows:-] SELECT column_name, is_nullable, udt_name, character_maximum_length, numeric_precision, numeric_precision_radix, numeric_scale, datetime_precision FROM information_schema.columns WHERE table_catalog = 'postgres' AND table_schema = CURRENT_SCHEMA() AND table_name = 'devices'

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[11.979ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'battery_level') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[2.578ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'current_carrier_network') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[2.466ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'subscriber_carrier_network') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[2.430ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'ud_id') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[3.004ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'token_update_recieved') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[3.699ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'erase') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.653ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'unlock_pin') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.823ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'model_name') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.808ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'local_host_name') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.997ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'bluetooth_mac') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.679ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'is_network_tethered') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.197ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'initial_tasks_run') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[2.445ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'next_push') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[2.392ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'last_device_info') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.981ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'device_name') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[5.729ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'is_device_locator_service_enabled') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[2.760ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'is_do_not_disturb_in_effect') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.336ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'eas_device_identifier') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.587ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'host_name') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.633ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'icc_id') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[1.215ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'updated_at') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[2.056ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'model') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[2.740ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'device_capacity') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))

2021/02/04 09:20:59 /Users/graham_gilbert/go/pkg/mod/gorm.io/driver/postgres@v1.0.6/migrator.go:249
[2.251ms] [rows:-] SELECT description FROM pg_catalog.pg_description WHERE objsubid = (SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'devices' AND column_name = 'modem_firmware_version') AND objoid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'devices' AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = CURRENT_SCHEMA()))
```