### PR TITLE
When we need to push a new profile make sure we can request the info …

### DIFF
--- a/director/profile.go
+++ b/director/profile.go
@@ -267,6 +267,11 @@ func ProcessDeviceProfiles(device types.Device, profiles []types.DeviceProfile, 
 		if err != nil {
 			return metadata, errors.Wrap(err, "Push Device")
 		}
+
+		err = setNextPushToThePast(device)
+		if err != nil {
+			return metadata, errors.Wrap(err, "Set last push to a date in the past")
+		}
 	}
 
 	return metadata, nil

--- a/director/webhook.go
+++ b/director/webhook.go
@@ -2,7 +2,6 @@ package director
 
 import (
 	"encoding/json"
-	intErrors "errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -14,8 +13,6 @@ import (
 	"github.com/mdmdirector/mdmdirector/utils"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-
-	"gorm.io/gorm"
 )
 
 func WebhookHandler(w http.ResponseWriter, r *http.Request) {
@@ -213,20 +210,6 @@ func RequestDeviceUpdate(device types.Device) {
 			ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
 		}
 
-	}
-
-	// hourAgo := time.Now().Add(1 * time.Hour)
-	thirtyMinsAgo := time.Now().Add(-30 * time.Minute)
-
-	if utils.DebugMode() {
-		thirtyMinsAgo = time.Now().Add(-5 * time.Minute)
-	}
-
-	if err = db.DB.Model(&deviceModel).Where("last_info_requested < ? AND ud_id = ?", thirtyMinsAgo, device.UDID).First(&device).Error; err != nil {
-		if intErrors.Is(err, gorm.ErrRecordNotFound) {
-			log.Debug("Last updated was under 30 minutes ago")
-			return
-		}
 	}
 
 	err = db.DB.Model(&deviceModel).Select("last_info_requested").Where("ud_id = ?", device.UDID).Updates(map[string]interface{}{"last_info_requested": time.Now()}).Error


### PR DESCRIPTION
…quicker.

This also removes the restriction on only sending commands every 30 minutes. We need to be able to request it more frequently since we are relying on this flow to get device profiles installed.