### PR TITLE
Correct command path and pincode interpolation

### DIFF
--- a/tools/device_lock
+++ b/tools/device_lock
@@ -4,13 +4,13 @@
 #          ./tools/device_lock $udid $pincode
 #
 source $MDMDIRECTOR_ENV_PATH
-endpoint="device_lock"
+endpoint="device/command/device_lock"
 jq -n \
   --arg udid "$1" \
-  --arg pincode "$2"
+  --arg pincode "$2" \
   '.udids = [$udid]
   |.value = true
   |.push_now = true
-  |.pin = "[$pincode]"
+  |.pin = $pincode
   '|\
   curl -u "mdmdirector:$API_TOKEN" -X POST "$SERVER_URL/$endpoint" -d@-


### PR DESCRIPTION
## What's up? 

Hi there, was trying the example commands. Kept getting `405`, looked into the `device_unlock` example and realized the path is probably outdated. Rest of the changes in line comments.