### PR TITLE
Add Error Checking for non-matching UDID

### DIFF
--- a/director/profile.go
+++ b/director/profile.go
@@ -892,7 +892,7 @@ func GetDeviceProfiles(w http.ResponseWriter, r *http.Request) {
 
 	notFoundErr := db.DB.First(&profiles, "device_ud_id = ?", vars["udid"]).Error
 	if errors.Is(notFoundErr, gorm.ErrRecordNotFound) {
-		errorMSG := fmt.Sprintf("Device Profiles returned no records found for device UDID = %s.\n", vars["udid"])
+		errorMSG := "Device Profiles returned no records found for device UDID in request."
 		w.WriteHeader(404)
 		log.Errorf(errorMSG)
 		_, _ = w.Write([]byte(errorMSG))


### PR DESCRIPTION
# Summary

resolves https://github.com/mdmdirector/mdmdirector/issues/78

The following adds some validation and sanitization for the `/device/{UDID}` endpoint where an invalid UDID would return all profiles on the server as Gorm drops the condition if it is evaluated to null. 

This introduces a change in behavior, where previously if a Serial Number was provided it would return all the matching profiles across all known UDID's I am unsure if this is a bug or a feature. 

## Changes

Move to use an inline query vs a struct based query, This approach also adds an additional query as an error check as the  `gorm.ErrRecordNotFound` is only returned on certain functions and `find` is not one of them as such this was necessary to prevent the return of an empty struct. 

This additional query should hopefully be a low enough impact to justify its inclusion over the potential of an invalid UDID being used to return all records in the DB causing DB timeouts or lockups. 

## Testing

All tests were conducted using curl against the API endpoint of `/profile/{udid}`

- Before
   - /profile/$foo -  returned all profiles
   - /profile/$invalidserial -  returned all profiles 
   - /profile/$invalidUDID - returned all profiles
   - /profile/$validUDID - returned specific profiles
   - /profile/$vailidSerial - returned all profiles over every UDID matched to that Serial number
- After
   - /profile/$foo - (returned the error message)
   - /profile/$invalidserial - (returned the error message) 
   - /profile/$invalidUDID - (reuturned the error message)
   - /profile/$validUDID - (returned profiles)
   - /profile/$vailidSerial - (returned the error message) 

### Before 

```
 curl -u "mdmdirector:neverleakpasswords" https://mdmdirector/profile/foo
(every device in the DB) 

>> echo $?
0
```
### After 

```
>> curl -u "mdmdirector:neverleakpasswords" https://mdmdirector/profile/foo
Device Profiles returned no records found for device UDID = foo.

>> echo $?
1
```