### PR TITLE
Support for verifying profile signing certificates and reinstalling profiles if the certificate is not our desired one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ curlprofile:
 	curl -o EnrollmentProfile.mobileconfig ${SERVER_URL}/mdm/enroll
 
 mdmdirector: build curlprofile
-	build/$(CURRENT_PLATFORM)/mdmdirector -micromdmurl="${SERVER_URL}" -micromdmapikey="supersecret" -debug -sign -cert=SigningCert.p12 -key-password=password -password=secret  -db-username=postgres -db-host=127.0.0.1 -db-port=5432 -db-name=postgres -db-password=password -db-sslmode=disable -loglevel=debug -escrowurl="${ESCROW_URL}" -clear-device-on-enroll -enrollment-profile=EnrollmentProfile.mobileconfig -enrollment-profile-signed -prometheus #-log-format=json
+	build/$(CURRENT_PLATFORM)/mdmdirector -micromdmurl="${SERVER_URL}" -micromdmapikey="supersecret" -debug -sign -cert=SigningCert.p12 -key-password=password -password=secret  -db-username=postgres -db-host=127.0.0.1 -db-port=5432 -db-name=postgres -db-password=password -db-sslmode=disable -loglevel=debug -escrowurl="${ESCROW_URL}" -clear-device-on-enroll -enrollment-profile=EnrollmentProfile.mobileconfig #-enrollment-profile-signed #-log-format=json
 
 test:
 	go test -cover -v ./...

--- a/director/certificate.go
+++ b/director/certificate.go
@@ -2,13 +2,10 @@ package director
 
 import (
 	"crypto/x509"
-	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"strconv"
 	"time"
 
-	"github.com/groob/plist"
 	"github.com/mdmdirector/mdmdirector/db"
 	"github.com/mdmdirector/mdmdirector/types"
 	"github.com/mdmdirector/mdmdirector/utils"
@@ -98,39 +95,9 @@ func validateScepCert(certListItem types.CertificateList, device types.Device) e
 		if days <= utils.ScepCertMinValidity() {
 			InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: errMsg, Metric: strconv.Itoa(days)})
 
-			data, err := ioutil.ReadFile(enrollmentProfile)
+			err := ReinstallEnrollmentProfile(device)
 			if err != nil {
-				return errors.Wrap(err, "Failed to read enrollment profile")
-			}
-
-			var profile types.DeviceProfile
-
-			err = plist.Unmarshal(data, &profile)
-			if err != nil {
-				return errors.Wrap(err, "Failed to unmarshal enrollment profile to struct")
-			}
-
-			profile.MobileconfigData = data
-
-			InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Pushing new enrollment profile"})
-
-			if utils.SignedEnrollmentProfile() {
-				DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Enrollment Profile pre-signed"})
-				var commandPayload types.CommandPayload
-				commandPayload.RequestType = "InstallProfile"
-				commandPayload.Payload = base64.StdEncoding.EncodeToString(profile.MobileconfigData)
-				commandPayload.UDID = device.UDID
-
-				_, err := SendCommand(commandPayload)
-				if err != nil {
-					return errors.Wrap(err, "Failed to push enrollment profile")
-				}
-			} else {
-				DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Signing Enrollment Profile"})
-				_, err = PushProfiles([]types.Device{device}, []types.DeviceProfile{profile})
-				if err != nil {
-					return errors.Wrap(err, "Failed to push enrollment profile")
-				}
+				return errors.Wrap(err, "ReinstallEnrollmentProfile")
 			}
 
 		} else {

--- a/director/certificate.go
+++ b/director/certificate.go
@@ -95,9 +95,9 @@ func validateScepCert(certListItem types.CertificateList, device types.Device) e
 		if days <= utils.ScepCertMinValidity() {
 			InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: errMsg, Metric: strconv.Itoa(days)})
 
-			err := ReinstallEnrollmentProfile(device)
+			err := reinstallEnrollmentProfile(device)
 			if err != nil {
-				return errors.Wrap(err, "ReinstallEnrollmentProfile")
+				return errors.Wrap(err, "reinstallEnrollmentProfile")
 			}
 
 		} else {

--- a/director/enrollment_profile.go
+++ b/director/enrollment_profile.go
@@ -1,6 +1,7 @@
 package director
 
 import (
+	"crypto/x509"
 	"encoding/base64"
 	"io/ioutil"
 
@@ -10,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func ReinstallEnrollmentProfile(device types.Device) error {
+func reinstallEnrollmentProfile(device types.Device) error {
 	enrollmentProfile := utils.EnrollmentProfile()
 	data, err := ioutil.ReadFile(enrollmentProfile)
 	if err != nil {
@@ -46,5 +47,44 @@ func ReinstallEnrollmentProfile(device types.Device) error {
 			return errors.Wrap(err, "Failed to push enrollment profile")
 		}
 	}
+	return nil
+}
+
+// If we have enabled signing profiles, this function will verify that the certificate used to sign the enrollment profile is the same as we have locally, and if it is not, will reinstall the profile
+func ensureCertOnEnrollmentProfile(device types.Device, profileLists []types.ProfileList, signingCert *x509.Certificate) error {
+	// Return early if we don't want to sign
+	if !utils.Sign() {
+		return nil
+	}
+
+	for i := range profileLists {
+		for j := range profileLists[i].PayloadContent {
+			if profileLists[i].PayloadContent[j].PayloadType == "com.apple.mdm" {
+				profileForVerification := ProfileForVerification{
+					PayloadUUID:       profileLists[i].PayloadUUID,
+					PayloadIdentifier: profileLists[i].PayloadIdentifier,
+					HashedPayloadUUID: profileLists[i].PayloadUUID,
+					DeviceUDID:        device.UDID,
+					Installed:         true, // You always want an enrollment profile to be installed
+				}
+
+				_, needsReinstall, err := validateProfileInProfileList(profileForVerification, profileLists, signingCert)
+				if err != nil {
+					return errors.Wrap(err, "validateProfileInProfileList")
+				}
+
+				if needsReinstall {
+					err = reinstallEnrollmentProfile(device)
+					if err != nil {
+						return errors.Wrap(err, "reinstallEnrollmentProfile")
+					}
+				}
+
+				return nil
+			}
+		}
+
+	}
+
 	return nil
 }

--- a/director/enrollment_profile.go
+++ b/director/enrollment_profile.go
@@ -1,0 +1,50 @@
+package director
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+
+	"github.com/groob/plist"
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/mdmdirector/mdmdirector/utils"
+	"github.com/pkg/errors"
+)
+
+func ReinstallEnrollmentProfile(device types.Device) error {
+	enrollmentProfile := utils.EnrollmentProfile()
+	data, err := ioutil.ReadFile(enrollmentProfile)
+	if err != nil {
+		return errors.Wrap(err, "Failed to read enrollment profile")
+	}
+
+	var profile types.DeviceProfile
+
+	err = plist.Unmarshal(data, &profile)
+	if err != nil {
+		return errors.Wrap(err, "Failed to unmarshal enrollment profile to struct")
+	}
+
+	profile.MobileconfigData = data
+
+	InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Pushing new enrollment profile"})
+
+	if utils.SignedEnrollmentProfile() {
+		DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Enrollment Profile pre-signed"})
+		var commandPayload types.CommandPayload
+		commandPayload.RequestType = "InstallProfile"
+		commandPayload.Payload = base64.StdEncoding.EncodeToString(profile.MobileconfigData)
+		commandPayload.UDID = device.UDID
+
+		_, err := SendCommand(commandPayload)
+		if err != nil {
+			return errors.Wrap(err, "Failed to push enrollment profile")
+		}
+	} else {
+		DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Signing Enrollment Profile"})
+		_, err = PushProfiles([]types.Device{device}, []types.DeviceProfile{profile})
+		if err != nil {
+			return errors.Wrap(err, "Failed to push enrollment profile")
+		}
+	}
+	return nil
+}

--- a/director/profile.go
+++ b/director/profile.go
@@ -273,27 +273,6 @@ func ProcessDeviceProfiles(device types.Device, profiles []types.DeviceProfile, 
 				}
 			}
 
-			// Cleanup the old duplicated profiles
-			// Remove this in a later version when this is not a problem anymore
-			// var count int64
-			// db.DB.Model(&types.DeviceProfile{}).Where("device_ud_id = ? AND payload_identifier = ?", device.UDID, profile.PayloadIdentifier).Count(&count)
-			// if count > 1 {
-			// 	var firstProfile types.DeviceProfile
-
-			// 	err = db.DB.Model(&types.DeviceProfile{}).Where("device_ud_id = ? AND payload_identifier = ?", device.UDID, profile.PayloadIdentifier).Not("hashed_payload_uuid = ?", profile.HashedPayloadUUID).First(&firstProfile).Error
-			// 	if err != nil {
-			// 		if !intErrors.Is(err, gorm.ErrRecordNotFound) {
-			// 			return metadata, errors.Wrap(err, "Cleanup old profiles: Select first profile")
-			// 		}
-			// 	}
-
-			// 	err = db.DB.Model(&types.DeviceProfile{}).Where("device_ud_id = ? AND payload_identifier = ?", device.UDID, profile.PayloadIdentifier).Not("id = ?", profile.ID).Delete(&types.DeviceProfile{}).Error
-			// 	if err != nil {
-			// 		if !intErrors.Is(err, gorm.ErrRecordNotFound) {
-			// 			return metadata, errors.Wrap(err, "Cleanup old profiles: Delete profiles")
-			// 		}
-			// 	}
-			// }
 		}
 
 		profileMetadata.HashedPayloadUUID = profile.HashedPayloadUUID
@@ -316,7 +295,6 @@ func ProcessDeviceProfiles(device types.Device, profiles []types.DeviceProfile, 
 
 func SavedProfileIsPresent(device types.Device, profile types.DeviceProfile) (bool, error) {
 	var savedProfile types.DeviceProfile
-	// var profileList types.ProfileList
 	// Make sure profile is marked as install = false
 	if err := db.DB.Where("device_ud_id = ? AND payload_identifier = ? AND installed = ?", device.UDID, profile.PayloadIdentifier, false).First(&savedProfile).Error; err != nil {
 		if intErrors.Is(err, gorm.ErrRecordNotFound) {
@@ -324,17 +302,6 @@ func SavedProfileIsPresent(device types.Device, profile types.DeviceProfile) (bo
 			return true, nil
 		}
 	}
-	// Make sure the profile isn't in the device's profilelist
-	// err := db.DB.Model(&profileList).Select("device_ud_id").Where("device_ud_id = ? AND payload_identifier = ?", device.UDID, profile.PayloadIdentifier).First(&profileList).Error
-	// if err != nil {
-	// 	if intErrors.Is(err, gorm.ErrRecordNotFound) {
-	// 		// If it's not found, we'll catch in the false return at the end. Else raise an error
-	// 		DebugLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, ProfileIdentifier: profile.PayloadIdentifier, Message: "Profile not found in device's ProfileList"})
-	// 		return false, nil
-	// 	}
-
-	// 	return true, errors.Wrap(err, "Could not load ProfileList for device")
-	// }
 
 	return false, nil
 }
@@ -367,37 +334,6 @@ func SavedDeviceProfileDiffers(device types.Device, profile types.DeviceProfile)
 	}
 
 	if !strings.EqualFold(profileList.PayloadUUID, profile.HashedPayloadUUID) {
-		// if profileList.PayloadUUID == "" {
-		// 	InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, ProfileIdentifier: profile.PayloadIdentifier, ProfileUUID: profile.HashedPayloadUUID, Message: "Hashed payload UUID is not present in ProfileList", Metric: profileList.PayloadUUID})
-		// } else {
-		// 	InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, ProfileIdentifier: profile.PayloadIdentifier, ProfileUUID: profile.HashedPayloadUUID, Message: "Hashed payload UUID doesn't match what's in ProfileList", Metric: profileList.PayloadUUID})
-		// }
-		// // May be waiting for a device to report in full - just bail if there profilelist count is 0
-		// var profileCount int
-		// err := db.DB.Model(&profileList).Where("device_ud_id = ?", device.UDID).Count(&profileCount).Error
-		// if err != nil {
-		// 	if !intErrors.Is(err, gorm.ErrRecordNotFound) {
-		// 		// If it's not found, we'll catch in the false return at the end. Else raise an error
-		// 		return true, errors.Wrap(err, "Could not load ProfileList for device")
-		// 	}
-		// }
-		// if profileCount == 0 {
-		// 	InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, ProfileIdentifier: profile.PayloadIdentifier, ProfileUUID: profile.HashedPayloadUUID, Message: "Device has an empty ProfileList stored"})
-		// }
-		// skipCommands := []string{"ProfileList", "SecurityInfo", "DeviceInformation", "CertificateList"}
-		// tenMinsAgo := time.Now().Add(-10 * time.Minute)
-		// for _, item := range skipCommands {
-		// 	inQueue := CommandInQueue(device, item, tenMinsAgo)
-		// 	if inQueue {
-		// 		msg := fmt.Sprintf("%v is in queue", item)
-		// 		InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, ProfileIdentifier: profile.PayloadIdentifier, ProfileUUID: profile.HashedPayloadUUID, Message: msg, Metric: profileList.PayloadUUID})
-		// 		return false, nil
-		// 	}
-		// }
-
-		// InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, ProfileIdentifier: profile.PayloadIdentifier, ProfileUUID: profile.HashedPayloadUUID, Message: "Requesting Device Info", Metric: profileList.PayloadUUID})
-		// _ = RequestAllDeviceInfo(device)
-
 		return false, nil
 	}
 

--- a/director/webhook.go
+++ b/director/webhook.go
@@ -149,6 +149,7 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 			err = plist.Unmarshal(out.AcknowledgeEvent.RawPayload, &profileListData)
 			if err != nil {
 				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
+				return
 			}
 			jsonBlob, err := profileListDataJSON(profileListData)
 			if err != nil {

--- a/types/profile.go
+++ b/types/profile.go
@@ -58,19 +58,19 @@ type ProfileListData struct {
 type ProfileList struct {
 	ID                       uuid.UUID `gorm:"primaryKey;type:uuid;default:uuid_generate_v4()"`
 	DeviceUDID               string
-	HasRemovalPasscode       bool          `plist:"HasRemovalPasscode"`
-	IsEncrypted              bool          `plist:"IsEncrypted"`
-	IsManaged                bool          `plist:"IsManaged"`
-	PayloadContent           []interface{} `plist:"PaylodContent" gorm:"-"`
-	PayloadDescription       string        `plist:"PayloadDescription"`
-	PayloadDisplayName       string        `plist:"PayloadDisplayName"`
-	PayloadIdentifier        string        `plist:"PayloadIdentifier"`
-	PayloadOrganization      string        `plist:"PayloadOrganization"`
-	PayloadRemovalDisallowed bool          `plist:"PayloadRemovalDisallowed"`
-	PayloadUUID              string        `plist:"PayloadUUID" gorm:"not null"`
-	PayloadVersion           int           `plist:"PayloadVersion"`
-	FullPayload              bool          `plist:"FullPayload"`
-	SignerCertificates       []byte        `plist:"SignerCertificates" gorm:"-"`
+	HasRemovalPasscode       bool                 `plist:"HasRemovalPasscode"`
+	IsEncrypted              bool                 `plist:"IsEncrypted"`
+	IsManaged                bool                 `plist:"IsManaged"`
+	PayloadContent           []PayloadContentItem `plist:"PayloadContent" gorm:"-"`
+	PayloadDescription       string               `plist:"PayloadDescription"`
+	PayloadDisplayName       string               `plist:"PayloadDisplayName"`
+	PayloadIdentifier        string               `plist:"PayloadIdentifier"`
+	PayloadOrganization      string               `plist:"PayloadOrganization"`
+	PayloadRemovalDisallowed bool                 `plist:"PayloadRemovalDisallowed"`
+	PayloadUUID              string               `plist:"PayloadUUID" gorm:"not null"`
+	PayloadVersion           int                  `plist:"PayloadVersion"`
+	FullPayload              bool                 `plist:"FullPayload"`
+	SignerCertificates       [][]byte             `plist:"SignerCertificates" gorm:"-"`
 }
 
 type MetadataItem struct {
@@ -82,6 +82,16 @@ type ProfileMetadata struct {
 	PayloadIdentifier string `json:"payload_identifier"`
 	PayloadUUID       string `json:"payload_uuid"`
 	HashedPayloadUUID string `json:"hashed_payload_uuid"`
+}
+
+// https://developer.apple.com/documentation/devicemanagement/profilelistresponse/profilelistitem/payloadcontentitem
+type PayloadContentItem struct {
+	PayloadDescription  string `plist:"PayloadDescription"`
+	PayloadDisplayName  string `plist:"PayloadDisplayName"`
+	PayloadIdentifier   string `plist:"PayloadIdentifier"`
+	PayloadOrganization string `plist:"PayloadOrganization"`
+	PayloadType         string `plist:"PayloadType"`
+	PayloadVersion      int    `plist:"PayloadVersion"`
 }
 
 func (profile *DeviceProfile) AfterCreate(tx *gorm.DB) (err error) {

--- a/types/profile.go
+++ b/types/profile.go
@@ -70,10 +70,10 @@ type ProfileList struct {
 	PayloadUUID              string        `plist:"PayloadUUID" gorm:"not null"`
 	PayloadVersion           int           `plist:"PayloadVersion"`
 	FullPayload              bool          `plist:"FullPayload"`
+	SignerCertificates       []byte        `plist:"SignerCertificates" gorm:"-"`
 }
 
 type MetadataItem struct {
-	// Device          Device            `json:"device"`
 	ProfileMetadata []ProfileMetadata `json:"profile_metadata"`
 }
 


### PR DESCRIPTION
This refactors the code to reinstall the enrollment profile into a more generic function, and if we have chosen to sign profiles, will verify the certificate is the same as we have locally, and if not, will reinstall the profile.