### PR TITLE
adding contributor docs

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,0 +1,5 @@
+## Contributing to mdmdirector
+
+### Sample Pull Request
+
+### Changelog

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,5 +1,0 @@
-## Contributing to mdmdirector
-
-### Sample Pull Request
-
-### Changelog

--- a/docs/start_here.md
+++ b/docs/start_here.md
@@ -1,0 +1,49 @@
+## Start here
+
+Welcome mobile device management enthusiasts!
+
+### Community Standards
+
+The project owner is a MacAdmin fan and community member.
+By participating in this project, you will adhere to the community
+standards present in the MacAdmin Community.
+
+Short Version of standards is included below.
+Long Version of standards is available at the link below.
+
+> #### [MacAdmin Foundation Code of Conduct](https://www.macadmins.org/code-of-conduct)
+>
+> ##### Short Version:
+> All community members are expected to:
+>
+> - respect differences in people, their ideas and opinions
+>
+> - treat one another with dignity and respect
+>
+> - respect and treat others fairly, regardless of race ancestry, place of origin, colour, >   ethnic origin, citizenship, religion, gender, sexual orientation, age or disability
+>
+> - respect the rights of others
+>
+> *Additionally*, if you are a reporter or a member of the press:
+>
+> - you must have that information listed in your profile - documentation on how to do that is available here
+>
+> - if you want to interview someone about something, you need to ask permission to interview them and inform them about where their comments may end up being published prior to the start of the interview.
+>
+> Everyone is welcome to participate, and no judgement will be made on members of the greater Mac community who are not a part of the community.
+>
+
+### Why use mdmdirector?
+
+- Open source!
+- Director your interactions with MicroMDM efficiently
+- Fun and community
+
+
+### Who uses mdmdirector?
+
+Industry professionals that are managing a fleet of hardware at scale.
+
+### Decision Making in mdmdirector
+
+### Contributing to mdmdirector

--- a/getting_involved_docs/changelog.md
+++ b/getting_involved_docs/changelog.md
@@ -1,0 +1,3 @@
+### Changelog
+
+Here is where we will log the most recent updates by user.

--- a/getting_involved_docs/changelog.md
+++ b/getting_involved_docs/changelog.md
@@ -1,3 +1,11 @@
 ### Changelog
 
 Here is where we will log the most recent updates by user.
+- Add github user name in first column.
+- Next get your [UTC time](https://www.utctime.net/).
+- Then convert that to a [unix timestamp](https://www.unixtimestamp.com/index.php).
+- Add that timestamp to the second column.
+
+| Name | Date |
+| Lily Leadership | 1660952975 |
+| Speedy Celena | 1665899020 |

--- a/getting_involved_docs/community_standards.md
+++ b/getting_involved_docs/community_standards.md
@@ -1,7 +1,3 @@
-## Start here
-
-Welcome mobile device management enthusiasts!
-
 ### Community Standards
 
 The project owner is a MacAdmin fan and community member.
@@ -32,18 +28,3 @@ Long Version of standards is available at the link below.
 >
 > Everyone is welcome to participate, and no judgement will be made on members of the greater Mac community who are not a part of the community.
 >
-
-### Why use mdmdirector?
-
-- Open source!
-- Director your interactions with MicroMDM efficiently
-- Fun and community
-
-
-### Who uses mdmdirector?
-
-Industry professionals that are managing a fleet of hardware at scale.
-
-### Decision Making in mdmdirector
-
-### Contributing to mdmdirector

--- a/getting_involved_docs/contribute.md
+++ b/getting_involved_docs/contribute.md
@@ -1,0 +1,9 @@
+## Contributing to mdmdirector
+
+List of steps on how to make a contribution
+
+- [Sample Pull Request](sample_pr.md)
+
+perhaps a sample pr?
+
+- [Changelog](changelog.md)

--- a/getting_involved_docs/start_here.md
+++ b/getting_involved_docs/start_here.md
@@ -1,0 +1,21 @@
+## Start here
+
+Welcome mobile device management enthusiasts!
+
+### [Community Standards](community_standards.md)
+
+
+### [Why use mdmdirector?](why_mdmdirector.md)
+
+- Open source!
+- Director your interactions with MicroMDM efficiently
+- Fun and community
+
+
+### [Who uses mdmdirector?](who_mdmdirector.md)
+
+Industry professionals that are managing a fleet of hardware at scale.
+
+### [Decision Making in mdmdirector](decisions.md)
+
+### [Contributing to mdmdirector](contribute.md)

--- a/getting_involved_docs/to_do.md
+++ b/getting_involved_docs/to_do.md
@@ -1,0 +1,9 @@
+### To Do List
+
+a table with identified project needs and associated skills needed for task
+
+
+| Task        | Skills Needed |
+| ----------- | ----------- |
+| Documentation - Add a profile      | Technical writing       |
+| Documentation - Remove aprofile   | Technical writing        |

--- a/getting_involved_docs/who_mdmdirector.md
+++ b/getting_involved_docs/who_mdmdirector.md
@@ -1,0 +1,3 @@
+### Who Uses mdmdirector?
+
+A description of ideal use cases and such.

--- a/getting_involved_docs/why_mdmdirector.md
+++ b/getting_involved_docs/why_mdmdirector.md
@@ -1,0 +1,3 @@
+### Why Use mdmdirector?
+
+List of cool things!


### PR DESCRIPTION
Added a directory "getting_involved_docs" that holds documentation on how to get involved as a contributor to mdmdirector.
"start_here" is a table of contents for the directory.

It includes links to the following pages:

- Community Standards
- Why Use mdmdirector?
- Who Uses mdmdirector?
- Decision making in mdmdirector
- Contributing to mdmdirector

Each page contains relevant information for users and developers. 

This documentation can support additional marketing for the software and also attract new open source contributors with a wide set of skills.
