### PR TITLE
[MDMv2] ProfileDownload endpoint in MDM Director

### DIFF
--- a/director/profile.go
+++ b/director/profile.go
@@ -1339,43 +1339,53 @@ func InstallAllProfiles(device types.Device) ([]types.Command, error) {
 	return pushedCommands, nil
 }
 
+func findMobileconfigData(udid, profileIdentifier string) ([]byte, error) {
+	var deviceProfile types.DeviceProfile
+	err := db.DB.Where("device_ud_id = ? AND payload_identifier = ?", udid, profileIdentifier).First(&deviceProfile).Error
+	if err == nil {
+		if !deviceProfile.Installed {
+			return nil, gorm.ErrRecordNotFound
+		}
+		return deviceProfile.MobileconfigData, nil
+	}
+	if !intErrors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("device profile lookup: %w", err)
+	}
+
+	var sharedProfile types.SharedProfile
+	err = db.DB.Where("payload_identifier = ?", profileIdentifier).First(&sharedProfile).Error
+	if err == nil {
+		if !sharedProfile.Installed {
+			return nil, gorm.ErrRecordNotFound
+		}
+		return sharedProfile.MobileconfigData, nil
+	}
+	if !intErrors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("shared profile lookup: %w", err)
+	}
+
+	return nil, gorm.ErrRecordNotFound
+}
+
 func ProfileDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	udid := vars["udid"]
 	profileIdentifier := vars["profileIdentifier"]
 
-	// Verify UDID matches X-Enrollment-ID header set by NanoMDM Auth Proxy
-	enrollmentID := r.Header.Get("X-Enrollment-ID")
-	if enrollmentID != udid {
+	if r.Header.Get("X-Enrollment-ID") != udid {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	var mobileconfigData []byte
-
-	// Try device-specific profile first
-	var deviceProfile types.DeviceProfile
-	err := db.DB.Where("device_ud_id = ? AND payload_identifier = ?", udid, profileIdentifier).First(&deviceProfile).Error
-	if err == nil {
-		if !deviceProfile.Installed {
-			http.Error(w, "Not Found", http.StatusNotFound)
-			return
-		}
-		mobileconfigData = deviceProfile.MobileconfigData
-	} else {
-		// Try shared profile
-		var sharedProfile types.SharedProfile
-		err = db.DB.Where("payload_identifier = ?", profileIdentifier).First(&sharedProfile).Error
-		if err == nil {
-			if !sharedProfile.Installed {
-				http.Error(w, "Not Found", http.StatusNotFound)
-				return
-			}
-			mobileconfigData = sharedProfile.MobileconfigData
-		} else {
-			http.Error(w, "Not Found", http.StatusNotFound)
-			return
-		}
+	mobileconfigData, err := findMobileconfigData(udid, profileIdentifier)
+	if intErrors.Is(err, gorm.ErrRecordNotFound) {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		log.Errorf("profile download lookup: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
 
 	responseData, err := signIfRequired(mobileconfigData)

--- a/director/profile_test.go
+++ b/director/profile_test.go
@@ -4,15 +4,18 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"flag"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/mdmdirector/mdmdirector/db"
 	"github.com/mdmdirector/mdmdirector/types"
-	"github.com/micromdm/go4/env"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"gorm.io/driver/postgres"
@@ -102,15 +105,6 @@ func TestValidateProfileInProfileList(t *testing.T) {
 	// disable logging for test
 	log.SetLevel(log.PanicLevel)
 	defer log.SetLevel(log.InfoLevel)
-
-	// set up global sign flag
-	var Sign bool
-	flag.BoolVar(
-		&Sign,
-		"sign",
-		env.Bool("SIGN", false),
-		"Sign profiles prior to sending to MicroMDM.",
-	)
 
 	// decode test signer cert
 	p, _ := pem.Decode([]byte(testSignerCert))
@@ -243,9 +237,13 @@ func TestValidateProfileInProfileList(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			Sign = test.signCheck
+			if test.signCheck {
+				flag.Set("sign", "true")
+			} else {
+				flag.Set("sign", "false")
+			}
 			var s *x509.Certificate
-			if Sign {
+			if test.signCheck {
 				s = signer
 			}
 			install, needsReinstall, err := validateProfileInProfileList(test.profile, test.profileList, s)
@@ -254,4 +252,192 @@ func TestValidateProfileInProfileList(t *testing.T) {
 			require.Equal(t, test.needsReinstall, needsReinstall, "unexpected needsReinstall status")
 		})
 	}
+}
+
+func init() {
+	// Register flags needed by utils accessor functions
+	if flag.Lookup("sign") == nil {
+		flag.Bool("sign", false, "Sign profiles prior to sending to MicroMDM.")
+	}
+	if flag.Lookup("key-password") == nil {
+		flag.String("key-password", "", "Signing key password")
+	}
+	if flag.Lookup("signing-private-key") == nil {
+		flag.String("signing-private-key", "", "Signing private key path")
+	}
+	if flag.Lookup("cert") == nil {
+		flag.String("cert", "", "Signing certificate path")
+	}
+}
+
+// newProfileDownloadRequest creates an HTTP request routed through a mux router
+func newProfileDownloadRequest(udid, profileIdentifier, enrollmentID string) (*httptest.ResponseRecorder, *http.Request) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/profiledownload/"+udid+"/"+profileIdentifier, nil)
+	if enrollmentID != "" {
+		req.Header.Set("X-Enrollment-ID", enrollmentID)
+	}
+	return rr, req
+}
+
+// serveProfileDownload routes the request through a mux router
+func serveProfileDownload(rr *httptest.ResponseRecorder, req *http.Request) {
+	router := mux.NewRouter()
+	router.HandleFunc("/profiledownload/{udid}/{profileIdentifier}", ProfileDownloadHandler).Methods("GET")
+	router.ServeHTTP(rr, req)
+}
+
+func TestProfileDownloadHandler_EnrollmentIDMismatch(t *testing.T) {
+	flag.Set("sign", "false")
+	rr, req := newProfileDownloadRequest("device-udid-123", "com.example.profile", "different-udid-456")
+	serveProfileDownload(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestProfileDownloadHandler_MissingEnrollmentID(t *testing.T) {
+	flag.Set("sign", "false")
+	rr, req := newProfileDownloadRequest("device-udid-123", "com.example.profile", "")
+	serveProfileDownload(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestProfileDownloadHandler_DeviceProfileFound(t *testing.T) {
+	flag.Set("sign", "false")
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	profileData := []byte("<?xml version=\"1.0\"?><plist><dict></dict></plist>")
+
+	mockSpy.ExpectQuery(`^SELECT \* FROM "device_profiles" WHERE device_ud_id = \$1 AND payload_identifier = \$2`).
+		WithArgs("device-udid-123", "com.example.profile").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"payload_identifier", "device_ud_id", "installed", "mobileconfig_data"}).
+				AddRow("com.example.profile", "device-udid-123", true, profileData),
+		)
+
+	rr, req := newProfileDownloadRequest("device-udid-123", "com.example.profile", "device-udid-123")
+	serveProfileDownload(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "application/x-apple-aspen-config", rr.Header().Get("Content-Type"))
+	assert.Equal(t, profileData, rr.Body.Bytes())
+}
+
+func TestProfileDownloadHandler_DeviceProfileNotInstalled(t *testing.T) {
+	flag.Set("sign", "false")
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	mockSpy.ExpectQuery(`^SELECT \* FROM "device_profiles" WHERE device_ud_id = \$1 AND payload_identifier = \$2`).
+		WithArgs("device-udid-123", "com.example.profile").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"payload_identifier", "device_ud_id", "installed", "mobileconfig_data"}).
+				AddRow("com.example.profile", "device-udid-123", false, []byte("data")),
+		)
+
+	rr, req := newProfileDownloadRequest("device-udid-123", "com.example.profile", "device-udid-123")
+	serveProfileDownload(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestProfileDownloadHandler_SharedProfileFallback(t *testing.T) {
+	flag.Set("sign", "false")
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	profileData := []byte("<?xml version=\"1.0\"?><plist><dict><key>shared</key></dict></plist>")
+
+	// Device profile not found
+	mockSpy.ExpectQuery(`^SELECT \* FROM "device_profiles" WHERE device_ud_id = \$1 AND payload_identifier = \$2`).
+		WithArgs("device-udid-123", "com.example.shared").
+		WillReturnRows(sqlmock.NewRows([]string{"payload_identifier", "device_ud_id", "installed", "mobileconfig_data"}))
+
+	// Shared profile found
+	mockSpy.ExpectQuery(`^SELECT \* FROM "shared_profiles" WHERE payload_identifier = \$1`).
+		WithArgs("com.example.shared").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "payload_identifier", "installed", "mobileconfig_data"}).
+				AddRow("00000000-0000-0000-0000-000000000001", "com.example.shared", true, profileData),
+		)
+
+	rr, req := newProfileDownloadRequest("device-udid-123", "com.example.shared", "device-udid-123")
+	serveProfileDownload(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "application/x-apple-aspen-config", rr.Header().Get("Content-Type"))
+	assert.Equal(t, profileData, rr.Body.Bytes())
+}
+
+func TestProfileDownloadHandler_SharedProfileNotInstalled(t *testing.T) {
+	flag.Set("sign", "false")
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	// Device profile not found
+	mockSpy.ExpectQuery(`^SELECT \* FROM "device_profiles" WHERE device_ud_id = \$1 AND payload_identifier = \$2`).
+		WithArgs("device-udid-123", "com.example.shared").
+		WillReturnRows(sqlmock.NewRows([]string{"payload_identifier", "device_ud_id", "installed", "mobileconfig_data"}))
+
+	// Shared profile found but not installed
+	mockSpy.ExpectQuery(`^SELECT \* FROM "shared_profiles" WHERE payload_identifier = \$1`).
+		WithArgs("com.example.shared").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "payload_identifier", "installed", "mobileconfig_data"}).
+				AddRow("00000000-0000-0000-0000-000000000001", "com.example.shared", false, []byte("data")),
+		)
+
+	rr, req := newProfileDownloadRequest("device-udid-123", "com.example.shared", "device-udid-123")
+	serveProfileDownload(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestProfileDownloadHandler_NoProfileFound(t *testing.T) {
+	flag.Set("sign", "false")
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	// Device profile not found
+	mockSpy.ExpectQuery(`^SELECT \* FROM "device_profiles" WHERE device_ud_id = \$1 AND payload_identifier = \$2`).
+		WithArgs("device-udid-123", "com.example.nonexistent").
+		WillReturnRows(sqlmock.NewRows([]string{"payload_identifier", "device_ud_id", "installed", "mobileconfig_data"}))
+
+	// Shared profile not found
+	mockSpy.ExpectQuery(`^SELECT \* FROM "shared_profiles" WHERE payload_identifier = \$1`).
+		WithArgs("com.example.nonexistent").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "payload_identifier", "installed", "mobileconfig_data"}))
+
+	rr, req := newProfileDownloadRequest("device-udid-123", "com.example.nonexistent", "device-udid-123")
+	serveProfileDownload(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestSignIfRequired_SigningDisabled(t *testing.T) {
+	// Ensure sign flag is false
+	flag.Set("sign", "false")
+
+	data := []byte("test mobileconfig data")
+	result, err := signIfRequired(data)
+
+	require.NoError(t, err)
+	assert.Equal(t, data, result)
 }

--- a/main.go
+++ b/main.go
@@ -333,6 +333,7 @@ func main() {
 	r.HandleFunc("/command/error", utils.BasicAuth(director.GetErrorCommands)).Methods("GET")
 	r.HandleFunc("/command", utils.BasicAuth(director.GetAllCommands)).Methods("GET")
 	r.HandleFunc("/health", director.HealthCheck).Methods("GET")
+	r.HandleFunc("/profiledownload/{udid}/{profileIdentifier}", director.ProfileDownloadHandler).Methods("GET")
 
 	director.InfoLogger(director.LogHolder{Message: "Connecting to database"})
 	if err := db.Open(); err != nil {


### PR DESCRIPTION
Add profile download endpoint for DDM declarations
                                                                                                                      
  Adds a new HTTP endpoint GET /profiledownload/{udid}/{profileIdentifier} that allows DDM declarations to reference and download .mobileconfig profiles directly from mdmdirector. This is required as in DDM LegacyProfile declaration needs a URL from where device can fetch the profile, instead of we sending the profile as part of command (MDM).

  Changes:

  - New endpoint (main.go): Registers ProfileDownloadHandler at /profiledownload/{udid}/{profileIdentifier}
  - New handler (director/profile.go): ProfileDownloadHandler serves device-specific or shared profiles by identifier,
   validates the requesting device via the X-Enrollment-ID header (set by the NanoMDM auth proxy), and returns only
  profiles marked as installed in DB
  - Refactor: Extracted duplicated signing logic from PushProfiles and PushSharedProfiles into a shared
  signIfRequired() helper, which is also reused in the new handler.
