### PR TITLE
Continue on failure for ProfileInstallation

### DIFF
--- a/director/profile.go
+++ b/director/profile.go
@@ -566,6 +566,7 @@ func DeleteProfileHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func SaveProfiles(devices []types.Device, profiles []types.DeviceProfile) error {
+	var errs []error
 	for i := range devices {
 		device := devices[i]
 		if device.UDID == "" {
@@ -580,7 +581,10 @@ func SaveProfiles(devices []types.Device, profiles []types.DeviceProfile) error 
 			err := db.DB.Save(&profileData).Error
 			if err != nil {
 				if !intErrors.Is(err, gorm.ErrRecordNotFound) {
-					return errors.Wrap(err, "Save incoming profile")
+					wrappedErr := fmt.Errorf("device %s profile %s: save incoming profile: %w", device.UDID, profileData.PayloadIdentifier, err)
+					log.Errorf("%v", wrappedErr)
+					errs = append(errs, wrappedErr)
+					continue
 				}
 			}
 
@@ -599,12 +603,15 @@ func SaveProfiles(devices []types.Device, profiles []types.DeviceProfile) error 
 				}).
 				Error
 			if err != nil {
-				return errors.Wrap(err, "Update boolean on profile")
+				wrappedErr := fmt.Errorf("device %s profile %s: update installed bool: %w", device.UDID, profileData.PayloadIdentifier, err)
+				log.Errorf("%v", wrappedErr)
+				errs = append(errs, wrappedErr)
+				continue
 			}
 
 		}
 	}
-	return nil
+	return intErrors.Join(errs...)
 }
 
 func PushProfiles(devices []types.Device, profiles []types.DeviceProfile) ([]types.Command, error) {
@@ -679,6 +686,7 @@ func SaveSharedProfiles(profiles []types.SharedProfile) error {
 		return nil
 	}
 
+	var errs []error
 	for _, profileData := range profiles {
 		if profileData.PayloadIdentifier != "" {
 			err := db.DB.Model(&profile).
@@ -686,27 +694,25 @@ func SaveSharedProfiles(profiles []types.SharedProfile) error {
 				Delete(&profile).
 				Error
 			if err != nil {
-				ErrorLogger(LogHolder{Message: err.Error()})
-				return errors.Wrap(err, "Deleting shared profiles")
+				wrappedErr := fmt.Errorf("profile %s: delete shared profile: %w", profileData.PayloadIdentifier, err)
+				ErrorLogger(LogHolder{Message: wrappedErr.Error()})
+				errs = append(errs, wrappedErr)
+				continue
 			}
 		}
 	}
 
-	tx2 := db.DB.Model(&profile)
 	for _, profileData := range profiles {
 		// utils.PrintStruct(profileData)
-		err := tx2.Create(&profileData).Error
+		err := db.DB.Model(&profile).Create(&profileData).Error
 		if err != nil {
-			ErrorLogger(LogHolder{Message: err.Error()})
+			wrappedErr := fmt.Errorf("profile %s: create shared profile: %w", profileData.PayloadIdentifier, err)
+			ErrorLogger(LogHolder{Message: wrappedErr.Error()})
+			errs = append(errs, wrappedErr)
 		}
 	}
 
-	err := tx2.Error
-	if err != nil {
-		return errors.Wrap(err, "Saving shared profiles")
-	}
-	// db.DB.Create(&profiles)
-	return nil
+	return intErrors.Join(errs...)
 }
 
 func DeleteSharedProfiles(

--- a/director/profile.go
+++ b/director/profile.go
@@ -29,6 +29,20 @@ import (
 	"gorm.io/gorm"
 )
 
+var signingPrivKey crypto.PrivateKey
+var signingCert *x509.Certificate
+
+// InitSigningKey loads the signing key and certificate at startup
+func InitSigningKey() error {
+	var err error
+	signingPrivKey, signingCert, err = loadSigningKey(
+		utils.KeyPassword(),
+		utils.KeyPath(),
+		utils.CertPath(),
+	)
+	return err
+}
+
 func PostProfileHandler(w http.ResponseWriter, r *http.Request) {
 	var profiles []types.DeviceProfile
 	var sharedProfiles []types.SharedProfile
@@ -617,19 +631,6 @@ func SaveProfiles(devices []types.Device, profiles []types.DeviceProfile) error 
 func PushProfiles(devices []types.Device, profiles []types.DeviceProfile) ([]types.Command, error) {
 	var pushedCommands []types.Command
 	var errs []error
-	var priv crypto.PrivateKey
-	var pub *x509.Certificate
-	if utils.Sign() {
-		var err error
-		priv, pub, err = loadSigningKey(
-			utils.KeyPassword(),
-			utils.KeyPath(),
-			utils.CertPath(),
-		)
-		if err != nil {
-			return nil, errors.Wrap(err, "loading signing certificate and private key")
-		}
-	}
 
 	for i := range devices {
 		device := devices[i]
@@ -650,7 +651,7 @@ func PushProfiles(devices []types.Device, profiles []types.DeviceProfile) ([]typ
 			)
 
 			if utils.Sign() {
-				signed, err := SignProfile(priv, pub, profileData.MobileconfigData)
+				signed, err := SignProfile(signingPrivKey, signingCert, profileData.MobileconfigData)
 				if err != nil {
 					wrappedErr := fmt.Errorf("device %s profile %s: signing profile: %w", device.UDID, profileData.PayloadIdentifier, err)
 					log.Errorf("%v", wrappedErr)
@@ -808,19 +809,6 @@ func PushSharedProfiles(
 ) ([]types.Command, error) {
 	var pushedCommands []types.Command
 	var errs []error
-	var priv crypto.PrivateKey
-	var pub *x509.Certificate
-	if utils.Sign() {
-		var err error
-		priv, pub, err = loadSigningKey(
-			utils.KeyPassword(),
-			utils.KeyPath(),
-			utils.CertPath(),
-		)
-		if err != nil {
-			return nil, errors.Wrap(err, "loading signing certificate and private key")
-		}
-	}
 
 	for i := range profiles {
 		profileData := profiles[i]
@@ -862,7 +850,7 @@ func PushSharedProfiles(
 			)
 
 			if utils.Sign() {
-				signed, err := SignProfile(priv, pub, profileData.MobileconfigData)
+				signed, err := SignProfile(signingPrivKey, signingCert, profileData.MobileconfigData)
 				if err != nil {
 					wrappedErr := fmt.Errorf("device %s profile %s: signing profile: %w", device.UDID, profileData.PayloadIdentifier, err)
 					log.Errorf("%v", wrappedErr)
@@ -989,13 +977,8 @@ func VerifyMDMProfiles(profileListData types.ProfileListData, device types.Devic
 		profilesForVerification = append(profilesForVerification, profileForVerification)
 	}
 
-	_, cert, err := loadSigningKey(utils.KeyPassword(), utils.KeyPath(), utils.CertPath())
-	if err != nil {
-		log.Errorf("loading signing certificate and private key: %v", err)
-	}
-
 	// ensure certificate matches on enrollment profile
-	err = ensureCertOnEnrollmentProfile(device, profileLists, cert)
+	err = ensureCertOnEnrollmentProfile(device, profileLists, signingCert)
 	if err != nil {
 		return errors.Wrap(err, "checkCertOnEnrollmentProfile")
 	}
@@ -1005,7 +988,7 @@ func VerifyMDMProfiles(profileListData types.ProfileListData, device types.Devic
 		isInstalled, needsReinstall, err := validateProfileInProfileList(
 			profileForVerification,
 			profileLists,
-			cert,
+			signingCert,
 		)
 		if err != nil {
 			return errors.Wrap(err, "validateProfileInProfileList")

--- a/director/profile.go
+++ b/director/profile.go
@@ -609,6 +609,21 @@ func SaveProfiles(devices []types.Device, profiles []types.DeviceProfile) error 
 
 func PushProfiles(devices []types.Device, profiles []types.DeviceProfile) ([]types.Command, error) {
 	var pushedCommands []types.Command
+	var errs []error
+	var priv crypto.PrivateKey
+	var pub *x509.Certificate
+	if utils.Sign() {
+		var err error
+		priv, pub, err = loadSigningKey(
+			utils.KeyPassword(),
+			utils.KeyPath(),
+			utils.CertPath(),
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "loading signing certificate and private key")
+		}
+	}
+
 	for i := range devices {
 		device := devices[i]
 		for i := range profiles {
@@ -628,18 +643,11 @@ func PushProfiles(devices []types.Device, profiles []types.DeviceProfile) ([]typ
 			)
 
 			if utils.Sign() {
-				priv, pub, err := loadSigningKey(
-					utils.KeyPassword(),
-					utils.KeyPath(),
-					utils.CertPath(),
-				)
-				if err != nil {
-					log.Errorf("loading signing certificate and private key: %v", err)
-					continue
-				}
 				signed, err := SignProfile(priv, pub, profileData.MobileconfigData)
 				if err != nil {
-					log.Errorf("signing profile with the specified key: %v", err)
+					wrappedErr := fmt.Errorf("device %s profile %s: signing profile: %w", device.UDID, profileData.PayloadIdentifier, err)
+					log.Errorf("%v", wrappedErr)
+					errs = append(errs, wrappedErr)
 					continue
 				}
 
@@ -652,7 +660,9 @@ func PushProfiles(devices []types.Device, profiles []types.DeviceProfile) ([]typ
 
 			command, err := SendCommand(commandPayload)
 			if err != nil {
-				ErrorLogger(LogHolder{Message: err.Error()})
+				wrappedErr := fmt.Errorf("device %s profile %s: send command: %w", device.UDID, profileData.PayloadIdentifier, err)
+				ErrorLogger(LogHolder{Message: wrappedErr.Error()})
+				errs = append(errs, wrappedErr)
 				continue
 			}
 			pushedCommands = append(pushedCommands, command)
@@ -660,7 +670,7 @@ func PushProfiles(devices []types.Device, profiles []types.DeviceProfile) ([]typ
 		}
 	}
 
-	return pushedCommands, nil
+	return pushedCommands, intErrors.Join(errs...)
 }
 
 func SaveSharedProfiles(profiles []types.SharedProfile) error {
@@ -791,6 +801,21 @@ func PushSharedProfiles(
 	profiles []types.SharedProfile,
 ) ([]types.Command, error) {
 	var pushedCommands []types.Command
+	var errs []error
+	var priv crypto.PrivateKey
+	var pub *x509.Certificate
+	if utils.Sign() {
+		var err error
+		priv, pub, err = loadSigningKey(
+			utils.KeyPassword(),
+			utils.KeyPath(),
+			utils.CertPath(),
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "loading signing certificate and private key")
+		}
+	}
+
 	for i := range profiles {
 		profileData := profiles[i]
 
@@ -798,7 +823,9 @@ func PushSharedProfiles(
 		var skipProfileDevices []types.DeviceProfile
 		err := db.DB.Select("device_ud_id").Where("payload_identifier = ?", profileData.PayloadIdentifier).Find(&skipProfileDevices).Error
 		if err != nil {
-			log.Errorf("PushSharedProfiles: could not query device-specific profiles: %v", err)
+			wrappedErr := fmt.Errorf("profile %s: query device-specific profiles: %w", profileData.PayloadIdentifier, err)
+			log.Errorf("PushSharedProfiles: %v", wrappedErr)
+			errs = append(errs, wrappedErr)
 			continue
 		}
 		skipUDIDs := make(map[string]struct{})
@@ -829,18 +856,11 @@ func PushSharedProfiles(
 			)
 
 			if utils.Sign() {
-				priv, pub, err := loadSigningKey(
-					utils.KeyPassword(),
-					utils.KeyPath(),
-					utils.CertPath(),
-				)
-				if err != nil {
-					log.Errorf("loading signing certificate and private key: %v", err)
-					continue
-				}
 				signed, err := SignProfile(priv, pub, profileData.MobileconfigData)
 				if err != nil {
-					log.Errorf("signing profile with the specified key: %v", err)
+					wrappedErr := fmt.Errorf("device %s profile %s: signing profile: %w", device.UDID, profileData.PayloadIdentifier, err)
+					log.Errorf("%v", wrappedErr)
+					errs = append(errs, wrappedErr)
 					continue
 				}
 
@@ -851,7 +871,9 @@ func PushSharedProfiles(
 
 			command, err := SendCommand(commandPayload)
 			if err != nil {
-				ErrorLogger(LogHolder{Message: err.Error()})
+				wrappedErr := fmt.Errorf("device %s profile %s: send command: %w", device.UDID, profileData.PayloadIdentifier, err)
+				ErrorLogger(LogHolder{Message: wrappedErr.Error()})
+				errs = append(errs, wrappedErr)
 				continue
 			}
 
@@ -859,7 +881,7 @@ func PushSharedProfiles(
 
 		}
 	}
-	return pushedCommands, nil
+	return pushedCommands, intErrors.Join(errs...)
 }
 
 type ProfileForVerification struct {

--- a/director/profile.go
+++ b/director/profile.go
@@ -713,6 +713,7 @@ func DeleteSharedProfiles(
 	profiles []types.SharedProfile,
 ) ([]types.Command, error) {
 	var pushedCommands []types.Command
+	var errs []error
 	for i := range profiles {
 		profileData := profiles[i]
 
@@ -720,7 +721,9 @@ func DeleteSharedProfiles(
 		var skipProfileDevices []types.DeviceProfile
 		err := db.DB.Select("device_ud_id").Where("payload_identifier = ?", profileData.PayloadIdentifier).Find(&skipProfileDevices).Error
 		if err != nil {
-			log.Errorf("DeleteSharedProfiles: could not query device-specific profiles: %v", err)
+			wrappedErr := fmt.Errorf("profile %s: query device-specific profiles: %w", profileData.PayloadIdentifier, err)
+			log.Errorf("DeleteSharedProfiles: %v", wrappedErr)
+			errs = append(errs, wrappedErr)
 			continue
 		}
 		skipUDIDs := make(map[string]struct{})
@@ -750,14 +753,16 @@ func DeleteSharedProfiles(
 			)
 			command, err := SendCommand(commandPayload)
 			if err != nil {
-				ErrorLogger(LogHolder{Message: err.Error()})
+				wrappedErr := fmt.Errorf("device %s profile %s: send command: %w", device.UDID, profileData.PayloadIdentifier, err)
+				ErrorLogger(LogHolder{Message: wrappedErr.Error()})
+				errs = append(errs, wrappedErr)
 				continue
 			}
 			pushedCommands = append(pushedCommands, command)
 		}
 	}
 
-	return pushedCommands, nil
+	return pushedCommands, intErrors.Join(errs...)
 }
 
 func DeleteDeviceProfiles(

--- a/main.go
+++ b/main.go
@@ -323,8 +323,8 @@ func main() {
 		if err := director.InitSigningKey(); err != nil {
 			log.Fatalf("Failed to load signing key: %v", err)
 		}
-  }
-  
+	}
+
 	// Initialize NanoMDM client only if configured to use NanoMDM
 	if MDMServerType == string(mdm.ServerTypeNanoMDM) {
 		mdm.InitClient(MicroMDMURL, MicroMDMAPIKey)

--- a/main.go
+++ b/main.go
@@ -309,6 +309,12 @@ func main() {
 		log.Fatal("loglevel value is not one of debug, info, warn or error.")
 	}
 
+	if utils.Sign() {
+		if err := director.InitSigningKey(); err != nil {
+			log.Fatalf("Failed to load signing key: %v", err)
+		}
+	}
+
 	r := mux.NewRouter()
 	r.HandleFunc("/webhook", director.WebhookHandler).Methods("POST")
 	r.HandleFunc("/profile", utils.BasicAuth(director.PostProfileHandler)).Methods("POST")


### PR DESCRIPTION
Fix: Continue on failure in profile push/delete operations

  Problem

  - In PushProfiles, errors from signing certificate loading and profile signing were logged but execution continued using potentially nil/invalid data 
  - In PushSharedProfiles, DeleteSharedProfiles, and DeleteDeviceProfiles, any single error (DB query failure, signing
   failure, or command send failure) caused the entire batch to abort early via an early return, leaving remaining
  devices unprocessed

  This meant a single device failure could block profile installation/deletion for all subsequent devices in the
  batch

  Fix

  - Added continue statements in PushProfiles after errors from certificate loading, profile signing, and SendCommand
  to prevent executing subsequent steps with invalid state.
  - Replaced early return error propagation in PushSharedProfiles, DeleteSharedProfiles, and DeleteDeviceProfiles with
   log.Errorf/ErrorLogger + continue, so a failure for one device/profile does not abort processing for the rest of
  the batch.