### PR TITLE
[MDMv2] InstallApplication migration from command (MDM) to DDM

### DIFF
--- a/ddm/client.go
+++ b/ddm/client.go
@@ -25,12 +25,7 @@ var kmfddmClient *KMFDDMClient
 
 // InitClient initializes the global KMFDDM client
 func InitClient(baseURL, apiKey string) {
-	kmfddmClient = &KMFDDMClient{
-		baseURL:    strings.TrimRight(baseURL, "/"),
-		username:   KMFDDMAuthUsername,
-		apiKey:     apiKey,
-		httpClient: &http.Client{Timeout: 20 * time.Second},
-	}
+	kmfddmClient = NewKMFDDMClient(baseURL, apiKey)
 }
 
 // Client returns the global KMFDDM client instance
@@ -55,7 +50,7 @@ func NewKMFDDMClient(baseURL, apiKey string) *KMFDDMClient {
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		username:   KMFDDMAuthUsername,
 		apiKey:     apiKey,
-		httpClient: &http.Client{},
+		httpClient: &http.Client{Timeout: 20 * time.Second},
 	}
 }
 

--- a/ddm/client.go
+++ b/ddm/client.go
@@ -94,8 +94,8 @@ func (c *KMFDDMClient) doRequest(method, urlPath string, queryParams url.Values,
 }
 
 // PutDeclaration stores a declaration in KMFDDM (creating or overwriting)
-// Returns changed=true when the declaration was new or modified (HTTP 304),
-// changed=false when unchanged (HTTP 204)
+// Returns changed=true when the declaration was new or modified (HTTP 204),
+// changed=false when unchanged (HTTP 304)
 func (c *KMFDDMClient) PutDeclaration(declaration Declaration, noNotify bool) (changed bool, err error) {
 	body, err := json.Marshal(declaration)
 	if err != nil {
@@ -114,9 +114,9 @@ func (c *KMFDDMClient) PutDeclaration(declaration Declaration, noNotify bool) (c
 	defer resp.Body.Close()
 
 	switch resp.StatusCode {
-	case http.StatusNotModified: // 304 = changed/new in KMFDDM
+	case http.StatusNoContent: // 204 = changed/new in KMFDDM
 		return true, nil
-	case http.StatusNoContent: // 204 = unchanged in KMFDDM
+	case http.StatusNotModified: // 304 = unchanged in KMFDDM
 		return false, nil
 	default:
 		respBody, _ := io.ReadAll(resp.Body)

--- a/ddm/client_test.go
+++ b/ddm/client_test.go
@@ -32,8 +32,8 @@ func TestPutDeclaration_Changed(t *testing.T) {
 		assert.Equal(t, "test.declaration.id", decl.Identifier)
 		assert.Equal(t, TypeLegacyProfile, decl.Type)
 
-		// 304 = changed/new in KMFDDM
-		w.WriteHeader(http.StatusNotModified)
+		// 204 = changed/new in KMFDDM
+		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 
@@ -53,8 +53,8 @@ func TestPutDeclaration_Changed(t *testing.T) {
 
 func TestPutDeclaration_Unchanged(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 204 = unchanged in KMFDDM
-		w.WriteHeader(http.StatusNoContent)
+		// 304 = unchanged in KMFDDM
+		w.WriteHeader(http.StatusNotModified)
 	}))
 	defer server.Close()
 
@@ -74,7 +74,7 @@ func TestPutDeclaration_NoNotifyFalse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// nonotify should not be in query params
 		assert.Empty(t, r.URL.Query().Get("nonotify"))
-		w.WriteHeader(http.StatusNotModified)
+		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 

--- a/ddm/client_test.go
+++ b/ddm/client_test.go
@@ -12,25 +12,25 @@ import (
 )
 
 func TestPutDeclaration_Changed(t *testing.T) {
+	var (
+		capturedMethod   string
+		capturedPath     string
+		capturedNoNotify string
+		capturedUser     string
+		capturedPass     string
+		capturedAuthOK   bool
+		capturedDecl     Declaration
+		capturedBodyErr  error
+	)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "PUT", r.Method)
-		assert.Equal(t, "/v1/declarations", r.URL.Path)
-		assert.Equal(t, "true", r.URL.Query().Get("nonotify"))
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedNoNotify = r.URL.Query().Get("nonotify")
+		capturedUser, capturedPass, capturedAuthOK = r.BasicAuth()
 
-		// Verify basic auth
-		user, pass, ok := r.BasicAuth()
-		assert.True(t, ok)
-		assert.Equal(t, "kmfddm", user)
-		assert.Equal(t, "test-api-key", pass)
-
-		// Verify body contains declaration
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		var decl Declaration
-		err = json.Unmarshal(body, &decl)
-		require.NoError(t, err)
-		assert.Equal(t, "test.declaration.id", decl.Identifier)
-		assert.Equal(t, TypeLegacyProfile, decl.Type)
+		body, _ := io.ReadAll(r.Body)
+		capturedBodyErr = json.Unmarshal(body, &capturedDecl)
 
 		// 204 = changed/new in KMFDDM
 		w.WriteHeader(http.StatusNoContent)
@@ -49,6 +49,16 @@ func TestPutDeclaration_Changed(t *testing.T) {
 	changed, err := kmfddmClient.PutDeclaration(decl, true)
 	require.NoError(t, err)
 	assert.True(t, changed)
+
+	assert.Equal(t, "PUT", capturedMethod)
+	assert.Equal(t, "/v1/declarations", capturedPath)
+	assert.Equal(t, "true", capturedNoNotify)
+	assert.True(t, capturedAuthOK)
+	assert.Equal(t, "kmfddm", capturedUser)
+	assert.Equal(t, "test-api-key", capturedPass)
+	require.NoError(t, capturedBodyErr)
+	assert.Equal(t, "test.declaration.id", capturedDecl.Identifier)
+	assert.Equal(t, TypeLegacyProfile, capturedDecl.Type)
 }
 
 func TestPutDeclaration_Unchanged(t *testing.T) {
@@ -108,14 +118,14 @@ func TestPutDeclaration_ServerError(t *testing.T) {
 func TestTouchDeclaration_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)
-		assert.Equal(t, "/v1/declarations/biz.airbnb.udid123.legacy_profile.com.test/touch", r.URL.Path)
+		assert.Equal(t, "/v1/declarations/com.example.udid123.legacy_profile.com.test/touch", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("nonotify"))
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 
 	kmfddmClient := NewKMFDDMClient(server.URL, "test-api-key")
-	err := kmfddmClient.TouchDeclaration("biz.airbnb.udid123.legacy_profile.com.test", true)
+	err := kmfddmClient.TouchDeclaration("com.example.udid123.legacy_profile.com.test", true)
 	require.NoError(t, err)
 }
 
@@ -135,7 +145,7 @@ func TestPutSetDeclaration_Changed(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "PUT", r.Method)
 		assert.Equal(t, "/v1/set-declarations/device-udid-123", r.URL.Path)
-		assert.Equal(t, "biz.airbnb.device-udid-123.legacy_profile.com.test", r.URL.Query().Get("declaration"))
+		assert.Equal(t, "com.example.device-udid-123.legacy_profile.com.test", r.URL.Query().Get("declaration"))
 		assert.Equal(t, "true", r.URL.Query().Get("nonotify"))
 		// 204 = changed for set-declarations
 		w.WriteHeader(http.StatusNoContent)
@@ -143,7 +153,7 @@ func TestPutSetDeclaration_Changed(t *testing.T) {
 	defer server.Close()
 
 	kmfddmClient := NewKMFDDMClient(server.URL, "test-api-key")
-	err := kmfddmClient.PutSetDeclaration("device-udid-123", "biz.airbnb.device-udid-123.legacy_profile.com.test", true)
+	err := kmfddmClient.PutSetDeclaration("device-udid-123", "com.example.device-udid-123.legacy_profile.com.test", true)
 	require.NoError(t, err)
 }
 
@@ -203,14 +213,14 @@ func TestPutEnrollmentSet_Unchanged(t *testing.T) {
 func TestDeleteDeclaration_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "DELETE", r.Method)
-		assert.Equal(t, "/v1/declarations/biz.airbnb.udid123.legacy_profile.com.test", r.URL.Path)
+		assert.Equal(t, "/v1/declarations/com.example.udid123.legacy_profile.com.test", r.URL.Path)
 		assert.Equal(t, "true", r.URL.Query().Get("nonotify"))
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 
 	kmfddmClient := NewKMFDDMClient(server.URL, "test-api-key")
-	err := kmfddmClient.DeleteDeclaration("biz.airbnb.udid123.legacy_profile.com.test", true)
+	err := kmfddmClient.DeleteDeclaration("com.example.udid123.legacy_profile.com.test", true)
 	require.NoError(t, err)
 }
 
@@ -230,14 +240,14 @@ func TestDeleteSetDeclaration_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "DELETE", r.Method)
 		assert.Equal(t, "/v1/set-declarations/device-udid-123", r.URL.Path)
-		assert.Equal(t, "biz.airbnb.device-udid-123.legacy_profile.com.test", r.URL.Query().Get("declaration"))
+		assert.Equal(t, "com.example.device-udid-123.legacy_profile.com.test", r.URL.Query().Get("declaration"))
 		assert.Equal(t, "true", r.URL.Query().Get("nonotify"))
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 
 	kmfddmClient := NewKMFDDMClient(server.URL, "test-api-key")
-	err := kmfddmClient.DeleteSetDeclaration("device-udid-123", "biz.airbnb.device-udid-123.legacy_profile.com.test", true)
+	err := kmfddmClient.DeleteSetDeclaration("device-udid-123", "com.example.device-udid-123.legacy_profile.com.test", true)
 	require.NoError(t, err)
 }
 

--- a/ddm/client_test.go
+++ b/ddm/client_test.go
@@ -93,7 +93,7 @@ func TestPutDeclaration_NoNotifyFalse(t *testing.T) {
 func TestPutDeclaration_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`{"error":"internal error"}`))
+		_, _ = w.Write([]byte(`{"error":"internal error"}`))
 	}))
 	defer server.Close()
 
@@ -162,7 +162,7 @@ func TestPutSetDeclaration_Unchanged(t *testing.T) {
 func TestPutSetDeclaration_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`{"error":"fail"}`))
+		_, _ = w.Write([]byte(`{"error":"fail"}`))
 	}))
 	defer server.Close()
 

--- a/ddm/naming.go
+++ b/ddm/naming.go
@@ -13,8 +13,8 @@ func LegacyProfileDeclarationID(prefix, udid, profileID string) string {
 
 // ProfileActivationDeclarationID returns the declaration identifier for an ActivationSimple for Profile
 // Format: <prefix>.<udid>.legacy_profile_activation.<profileID>
-func ProfileActivationDeclarationID(udid, profileID string) string {
-	return fmt.Sprintf("%s.%s.legacy_profile_activation.%s", declarationPrefix, udid, profileID)
+func ProfileActivationDeclarationID(prefix, udid, profileID string) string {
+	return fmt.Sprintf("%s.%s.legacy_profile_activation.%s", prefix, udid, profileID)
 }
 
 // ProfileDownloadURL constructs the URL a device will use to fetch profile data
@@ -24,13 +24,13 @@ func ProfileDownloadURL(nanoMDMURL, udid, payloadIdentifier string) string {
 }
 
 // PackageDeclarationID returns the declaration identifier for a Package declaration
-// Format: biz.airbnb.<udid>.package.<packageUUID>
-func PackageDeclarationID(udid, packageUUID string) string {
-	return fmt.Sprintf("%s.%s.package.%s", declarationPrefix, udid, packageUUID)
+// Format: <prefix>.<udid>.package.<packageUUID>
+func PackageDeclarationID(prefix, udid, packageUUID string) string {
+	return fmt.Sprintf("%s.%s.package.%s", prefix, udid, packageUUID)
 }
 
 // PackageActivationDeclarationID returns the declaration identifier for the ActivationSimple for Package
-// Format: biz.airbnb.<udid>.package_activation.<packageUUID>
-func PackageActivationDeclarationID(udid, packageUUID string) string {
-	return fmt.Sprintf("%s.%s.package_activation.%s", declarationPrefix, udid, packageUUID)
+// Format: <prefix>.<udid>.package_activation.<packageUUID>
+func PackageActivationDeclarationID(prefix, udid, packageUUID string) string {
+	return fmt.Sprintf("%s.%s.package_activation.%s", prefix, udid, packageUUID)
 }

--- a/ddm/naming.go
+++ b/ddm/naming.go
@@ -13,9 +13,9 @@ func LegacyProfileDeclarationID(udid, profileID string) string {
 	return fmt.Sprintf("%s.%s.legacy_profile.%s", declarationPrefix, udid, profileID)
 }
 
-// ActivationDeclarationID returns the declaration identifier for an ActivationSimple
+// ProfileActivationDeclarationID returns the declaration identifier for an ActivationSimple for Profile
 // Format: biz.airbnb.<udid>.legacy_profile_activation.<profileID>
-func ActivationDeclarationID(udid, profileID string) string {
+func ProfileActivationDeclarationID(udid, profileID string) string {
 	return fmt.Sprintf("%s.%s.legacy_profile_activation.%s", declarationPrefix, udid, profileID)
 }
 
@@ -23,4 +23,16 @@ func ActivationDeclarationID(udid, profileID string) string {
 // The URL is routed through NanoMDM's authentication proxy to MDMDirector
 func ProfileDownloadURL(nanoMDMURL, udid, payloadIdentifier string) string {
 	return fmt.Sprintf("%s/authproxy/profiledownload/%s/%s", strings.TrimRight(nanoMDMURL, "/"), udid, payloadIdentifier)
+}
+
+// PackageDeclarationID returns the declaration identifier for a Package declaration
+// Format: biz.airbnb.<udid>.package.<packageUUID>
+func PackageDeclarationID(udid, packageUUID string) string {
+	return fmt.Sprintf("%s.%s.package.%s", declarationPrefix, udid, packageUUID)
+}
+
+// PackageActivationDeclarationID returns the declaration identifier for the ActivationSimple for Package
+// Format: biz.airbnb.<udid>.package_activation.<packageUUID>
+func PackageActivationDeclarationID(udid, packageUUID string) string {
+	return fmt.Sprintf("%s.%s.package_activation.%s", declarationPrefix, udid, packageUUID)
 }

--- a/ddm/naming_test.go
+++ b/ddm/naming_test.go
@@ -16,17 +16,17 @@ func TestLegacyProfileDeclarationID(t *testing.T) {
 	}{
 		{
 			name:      "basic identifiers",
-			prefix:    "biz.airbnb",
+			prefix:    "com.example",
 			udid:      "ABCD-1234",
-			profileID: "com.airbnb.mdm.wifi",
-			expected:  "biz.airbnb.ABCD-1234.legacy_profile.com.airbnb.mdm.wifi",
+			profileID: "com.example.mdm.wifi",
+			expected:  "com.example.ABCD-1234.legacy_profile.com.example.mdm.wifi",
 		},
 		{
 			name:      "uuid-style udid",
-			prefix:    "biz.airbnb",
+			prefix:    "com.example",
 			udid:      "00000000-0000-0000-0000-000000000001",
 			profileID: "com.example.profile",
-			expected:  "biz.airbnb.00000000-0000-0000-0000-000000000001.legacy_profile.com.example.profile",
+			expected:  "com.example.00000000-0000-0000-0000-000000000001.legacy_profile.com.example.profile",
 		},
 	}
 	for _, tt := range tests {
@@ -47,15 +47,15 @@ func TestActivationDeclarationID(t *testing.T) {
 	}{
 		{
 			name:      "basic identifiers",
-			prefix:    "biz.airbnb",
+			prefix:    "com.example",
 			udid:      "ABCD-1234",
-			profileID: "com.airbnb.mdm.wifi",
-			expected:  "biz.airbnb.ABCD-1234.legacy_profile_activation.com.airbnb.mdm.wifi",
+			profileID: "com.example.mdm.wifi",
+			expected:  "com.example.ABCD-1234.legacy_profile_activation.com.example.mdm.wifi",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ProfileActivationDeclarationID(tt.udid, tt.profileID)
+			result := ProfileActivationDeclarationID(tt.prefix, tt.udid, tt.profileID)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -64,26 +64,29 @@ func TestActivationDeclarationID(t *testing.T) {
 func TestPackageDeclarationID(t *testing.T) {
 	tests := []struct {
 		name        string
+		prefix      string
 		udid        string
 		packageUUID string
 		expected    string
 	}{
 		{
 			name:        "basic identifiers",
+			prefix:      "com.example",
 			udid:        "ABCD-1234",
 			packageUUID: "550e8400-e29b-41d4-a716-446655440000",
-			expected:    "biz.airbnb.ABCD-1234.package.550e8400-e29b-41d4-a716-446655440000",
+			expected:    "com.example.ABCD-1234.package.550e8400-e29b-41d4-a716-446655440000",
 		},
 		{
 			name:        "uuid-style udid",
+			prefix:      "com.example",
 			udid:        "00000000-0000-0000-0000-000000000001",
 			packageUUID: "550e8400-e29b-41d4-a716-446655440000",
-			expected:    "biz.airbnb.00000000-0000-0000-0000-000000000001.package.550e8400-e29b-41d4-a716-446655440000",
+			expected:    "com.example.00000000-0000-0000-0000-000000000001.package.550e8400-e29b-41d4-a716-446655440000",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := PackageDeclarationID(tt.udid, tt.packageUUID)
+			result := PackageDeclarationID(tt.prefix, tt.udid, tt.packageUUID)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -92,28 +95,29 @@ func TestPackageDeclarationID(t *testing.T) {
 func TestPackageActivationDeclarationID(t *testing.T) {
 	tests := []struct {
 		name        string
+		prefix      string
 		udid        string
 		packageUUID string
 		expected    string
 	}{
 		{
 			name:        "basic identifiers",
-      prefix:    "biz.airbnb",
+			prefix:      "com.example",
 			udid:        "ABCD-1234",
 			packageUUID: "550e8400-e29b-41d4-a716-446655440000",
-			expected:    "biz.airbnb.ABCD-1234.package_activation.550e8400-e29b-41d4-a716-446655440000",
+			expected:    "com.example.ABCD-1234.package_activation.550e8400-e29b-41d4-a716-446655440000",
 		},
 		{
 			name:        "uuid-style udid",
-      prefix:    "biz.airbnb",
+			prefix:      "com.example",
 			udid:        "00000000-0000-0000-0000-000000000001",
 			packageUUID: "550e8400-e29b-41d4-a716-446655440000",
-			expected:    "biz.airbnb.00000000-0000-0000-0000-000000000001.package_activation.550e8400-e29b-41d4-a716-446655440000",
+			expected:    "com.example.00000000-0000-0000-0000-000000000001.package_activation.550e8400-e29b-41d4-a716-446655440000",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := PackageActivationDeclarationID(tt.prefix, tt.udid, tt.profileID)
+			result := PackageActivationDeclarationID(tt.prefix, tt.udid, tt.packageUUID)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -129,17 +133,17 @@ func TestProfileDownloadURL(t *testing.T) {
 	}{
 		{
 			name:              "basic URL",
-			nanoMDMURL:        "https://nanomdm.airbnb.biz",
+			nanoMDMURL:        "https://mdm.example.com",
 			udid:              "ABCD-1234",
-			payloadIdentifier: "com.airbnb.mdm.wifi",
-			expected:          "https://nanomdm.airbnb.biz/authproxy/profiledownload/ABCD-1234/com.airbnb.mdm.wifi",
+			payloadIdentifier: "com.example.mdm.wifi",
+			expected:          "https://mdm.example.com/authproxy/profiledownload/ABCD-1234/com.example.mdm.wifi",
 		},
 		{
 			name:              "trailing slash in base URL",
-			nanoMDMURL:        "https://nanomdm.airbnb.biz/",
+			nanoMDMURL:        "https://mdm.example.com/",
 			udid:              "ABCD-1234",
-			payloadIdentifier: "com.airbnb.mdm.wifi",
-			expected:          "https://nanomdm.airbnb.biz/authproxy/profiledownload/ABCD-1234/com.airbnb.mdm.wifi",
+			payloadIdentifier: "com.example.mdm.wifi",
+			expected:          "https://mdm.example.com/authproxy/profiledownload/ABCD-1234/com.example.mdm.wifi",
 		},
 	}
 	for _, tt := range tests {

--- a/ddm/naming_test.go
+++ b/ddm/naming_test.go
@@ -56,6 +56,62 @@ func TestActivationDeclarationID(t *testing.T) {
 	}
 }
 
+func TestPackageDeclarationID(t *testing.T) {
+	tests := []struct {
+		name        string
+		udid        string
+		packageUUID string
+		expected    string
+	}{
+		{
+			name:        "basic identifiers",
+			udid:        "ABCD-1234",
+			packageUUID: "550e8400-e29b-41d4-a716-446655440000",
+			expected:    "biz.airbnb.ABCD-1234.package.550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name:        "uuid-style udid",
+			udid:        "00000000-0000-0000-0000-000000000001",
+			packageUUID: "550e8400-e29b-41d4-a716-446655440000",
+			expected:    "biz.airbnb.00000000-0000-0000-0000-000000000001.package.550e8400-e29b-41d4-a716-446655440000",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PackageDeclarationID(tt.udid, tt.packageUUID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPackageActivationDeclarationID(t *testing.T) {
+	tests := []struct {
+		name        string
+		udid        string
+		packageUUID string
+		expected    string
+	}{
+		{
+			name:        "basic identifiers",
+			udid:        "ABCD-1234",
+			packageUUID: "550e8400-e29b-41d4-a716-446655440000",
+			expected:    "biz.airbnb.ABCD-1234.package_activation.550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name:        "uuid-style udid",
+			udid:        "00000000-0000-0000-0000-000000000001",
+			packageUUID: "550e8400-e29b-41d4-a716-446655440000",
+			expected:    "biz.airbnb.00000000-0000-0000-0000-000000000001.package_activation.550e8400-e29b-41d4-a716-446655440000",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PackageActivationDeclarationID(tt.udid, tt.packageUUID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestProfileDownloadURL(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/ddm/naming_test.go
+++ b/ddm/naming_test.go
@@ -50,7 +50,7 @@ func TestActivationDeclarationID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := ActivationDeclarationID(tt.udid, tt.profileID)
+			result := ProfileActivationDeclarationID(tt.udid, tt.profileID)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/ddm/types.go
+++ b/ddm/types.go
@@ -4,6 +4,7 @@ package ddm
 const (
 	TypeLegacyProfile    = "com.apple.configuration.legacy"
 	TypeActivationSimple = "com.apple.activation.simple"
+	TypePackage          = "com.apple.configuration.management.package"
 )
 
 // Declaration represents a KMFDDM declaration object
@@ -23,4 +24,9 @@ type LegacyProfilePayload struct {
 // ActivationSimplePayload is the Payload for a com.apple.activation.simple declaration
 type ActivationSimplePayload struct {
 	StandardConfigurations []string `json:"StandardConfigurations"`
+}
+
+// PackagePayload is the Payload for a com.apple.configuration.management.package declaration
+type PackagePayload struct {
+	ManifestURL string `json:"ManifestURL"`
 }

--- a/director/ddm_app_push.go
+++ b/director/ddm_app_push.go
@@ -4,6 +4,7 @@ import (
 	"github.com/mdmdirector/mdmdirector/db"
 	"github.com/mdmdirector/mdmdirector/ddm"
 	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/mdmdirector/mdmdirector/utils"
 
 	"github.com/pkg/errors"
 )
@@ -11,8 +12,9 @@ import (
 // PushApplicationViaDDM pushes a single application via DDM declarations for a single device
 // app.ID must be populated (loaded from DB) - used as declaration identifier
 func PushApplicationViaDDM(client *ddm.KMFDDMClient, udid string, app types.DeviceInstallApplication) error {
-	packageDeclID := ddm.PackageDeclarationID(udid, app.ID.String())
-	activationDeclID := ddm.PackageActivationDeclarationID(udid, app.ID.String())
+	declarationPrefix := utils.DDMDeclarationPrefix()
+	packageDeclID := ddm.PackageDeclarationID(declarationPrefix, udid, app.ID.String())
+	activationDeclID := ddm.PackageActivationDeclarationID(declarationPrefix, udid, app.ID.String())
 
 	// Step 1: PUT Package declaration (noNotify=true)
 	packageDecl := ddm.Declaration{

--- a/director/ddm_app_push.go
+++ b/director/ddm_app_push.go
@@ -28,7 +28,7 @@ func PushApplicationViaDDM(client *ddm.KMFDDMClient, udid string, app types.Devi
 		return errors.Wrapf(err, "PushApplicationViaDDM: PUT Package declaration for %s on %s", app.ManifestURL, udid)
 	}
 
-	// If unchanged (204), touch to force reinstall
+	// If unchanged (304), touch to force reinstall
 	if !packageChanged {
 		if err := client.TouchDeclaration(packageDeclID, true); err != nil {
 			return errors.Wrapf(err, "PushApplicationViaDDM: touch Package declaration for %s on %s", app.ManifestURL, udid)
@@ -49,7 +49,7 @@ func PushApplicationViaDDM(client *ddm.KMFDDMClient, udid string, app types.Devi
 		return errors.Wrapf(err, "PushApplicationViaDDM: PUT ActivationSimple declaration for %s on %s", app.ManifestURL, udid)
 	}
 
-	// If unchanged (204), touch to force reinstall
+	// If unchanged (304), touch to force reinstall
 	if !activationChanged {
 		if err := client.TouchDeclaration(activationDeclID, true); err != nil {
 			return errors.Wrapf(err, "PushApplicationViaDDM: touch ActivationSimple declaration for %s on %s", app.ManifestURL, udid)

--- a/director/ddm_app_push.go
+++ b/director/ddm_app_push.go
@@ -1,0 +1,161 @@
+package director
+
+import (
+	"github.com/mdmdirector/mdmdirector/db"
+	"github.com/mdmdirector/mdmdirector/ddm"
+	"github.com/mdmdirector/mdmdirector/types"
+
+	"github.com/pkg/errors"
+)
+
+// PushApplicationViaDDM pushes a single application via DDM declarations for a single device
+// app.ID must be populated (loaded from DB) - used as declaration identifier
+func PushApplicationViaDDM(client *ddm.KMFDDMClient, udid string, app types.DeviceInstallApplication) error {
+	packageDeclID := ddm.PackageDeclarationID(udid, app.ID.String())
+	activationDeclID := ddm.PackageActivationDeclarationID(udid, app.ID.String())
+
+	// Step 1: PUT Package declaration (noNotify=true)
+	packageDecl := ddm.Declaration{
+		Identifier: packageDeclID,
+		Type:       ddm.TypePackage,
+		Payload: ddm.PackagePayload{
+			ManifestURL: app.ManifestURL,
+		},
+	}
+
+	packageChanged, err := client.PutDeclaration(packageDecl, true)
+	if err != nil {
+		return errors.Wrapf(err, "PushApplicationViaDDM: PUT Package declaration for %s on %s", app.ManifestURL, udid)
+	}
+
+	// If unchanged (204), touch to force reinstall
+	if !packageChanged {
+		if err := client.TouchDeclaration(packageDeclID, true); err != nil {
+			return errors.Wrapf(err, "PushApplicationViaDDM: touch Package declaration for %s on %s", app.ManifestURL, udid)
+		}
+	}
+
+	// Step 2: PUT ActivationSimple declaration referencing the Package declaration (noNotify=true)
+	activationDecl := ddm.Declaration{
+		Identifier: activationDeclID,
+		Type:       ddm.TypeActivationSimple,
+		Payload: ddm.ActivationSimplePayload{
+			StandardConfigurations: []string{packageDeclID},
+		},
+	}
+
+	activationChanged, err := client.PutDeclaration(activationDecl, true)
+	if err != nil {
+		return errors.Wrapf(err, "PushApplicationViaDDM: PUT ActivationSimple declaration for %s on %s", app.ManifestURL, udid)
+	}
+
+	// If unchanged (204), touch to force reinstall
+	if !activationChanged {
+		if err := client.TouchDeclaration(activationDeclID, true); err != nil {
+			return errors.Wrapf(err, "PushApplicationViaDDM: touch ActivationSimple declaration for %s on %s", app.ManifestURL, udid)
+		}
+	}
+
+	// Step 3: Associate Package declaration with the device's set (noNotify=true)
+	if err := client.PutSetDeclaration(udid, packageDeclID, true); err != nil {
+		return errors.Wrapf(err, "PushApplicationViaDDM: PUT set-declaration (package) for %s on %s", app.ManifestURL, udid)
+	}
+
+	// Step 4: Associate ActivationSimple declaration with the device's set (noNotify=true)
+	if err := client.PutSetDeclaration(udid, activationDeclID, true); err != nil {
+		return errors.Wrapf(err, "PushApplicationViaDDM: PUT set-declaration (activation) for %s on %s", app.ManifestURL, udid)
+	}
+
+	// Step 5: Associate enrollment with the set (noNotify=false — triggers DDM sync)
+	if err := client.PutEnrollmentSet(udid, udid, false); err != nil {
+		return errors.Wrapf(err, "PushApplicationViaDDM: PUT enrollment-set for %s", udid)
+	}
+
+	return nil
+}
+
+// PushApplicationsViaDDM pushes a device-specific application to all given devices via DDM
+func PushApplicationsViaDDM(devices []types.Device, manifestURL string) error {
+	client, err := ddm.Client()
+	if err != nil {
+		return err
+	}
+
+	for i := range devices {
+		device := devices[i]
+
+		var app types.DeviceInstallApplication
+		if err := db.DB.Where("device_ud_id = ? AND manifest_url = ?", device.UDID, manifestURL).First(&app).Error; err != nil {
+			return errors.Wrapf(err, "PushApplicationsViaDDM: querying DeviceInstallApplication for %s on %s", manifestURL, device.UDID)
+		}
+
+		InfoLogger(LogHolder{
+			DeviceUDID:   device.UDID,
+			DeviceSerial: device.SerialNumber,
+			Message:      "Pushing application via DDM",
+		})
+
+		if err := PushApplicationViaDDM(client, device.UDID, app); err != nil {
+			ErrorLogger(LogHolder{
+				Message:      err.Error(),
+				DeviceUDID:   device.UDID,
+				DeviceSerial: device.SerialNumber,
+			})
+			continue
+		}
+
+		InfoLogger(LogHolder{
+			DeviceUDID:   device.UDID,
+			DeviceSerial: device.SerialNumber,
+			Message:      "Pushed application via DDM",
+		})
+	}
+
+	return nil
+}
+
+// PushSharedApplicationsViaDDM pushes a shared application to all given devices via DDM
+func PushSharedApplicationsViaDDM(devices []types.Device, manifestURL string) error {
+	client, err := ddm.Client()
+	if err != nil {
+		return err
+	}
+
+	var sharedApp types.SharedInstallApplication
+	if err := db.DB.Where("manifest_url = ?", manifestURL).First(&sharedApp).Error; err != nil {
+		return errors.Wrapf(err, "PushSharedApplicationsViaDDM: querying SharedInstallApplication for %s", manifestURL)
+	}
+
+	// Build a DeviceInstallApplication carrying the shared app's stable UUID and manifest URL
+	app := types.DeviceInstallApplication{
+		ID:          sharedApp.ID,
+		ManifestURL: sharedApp.ManifestURL,
+	}
+
+	for i := range devices {
+		device := devices[i]
+
+		InfoLogger(LogHolder{
+			DeviceUDID:   device.UDID,
+			DeviceSerial: device.SerialNumber,
+			Message:      "Pushing shared application via DDM",
+		})
+
+		if err := PushApplicationViaDDM(client, device.UDID, app); err != nil {
+			ErrorLogger(LogHolder{
+				Message:      err.Error(),
+				DeviceUDID:   device.UDID,
+				DeviceSerial: device.SerialNumber,
+			})
+			continue
+		}
+
+		InfoLogger(LogHolder{
+			DeviceUDID:   device.UDID,
+			DeviceSerial: device.SerialNumber,
+			Message:      "Pushed shared application via DDM",
+		})
+	}
+
+	return nil
+}

--- a/director/ddm_app_push_test.go
+++ b/director/ddm_app_push_test.go
@@ -85,8 +85,8 @@ func TestPushApplicationViaDDM_UnchangedDeclarations_TouchCalled(t *testing.T) {
 	server, requests, statusOverrides := newMockKMFDDM(t)
 	defer server.Close()
 
-	// Override PUT declarations to return 204 (unchanged)
-	statusOverrides["PUT /v1/declarations"] = http.StatusNoContent
+	// Override PUT declarations to return 304 (unchanged)
+	statusOverrides["PUT /v1/declarations"] = http.StatusNotModified
 
 	client := ddm.NewKMFDDMClient(server.URL, "testapikey")
 	app := newTestApp("https://example.com/app.plist")
@@ -94,7 +94,7 @@ func TestPushApplicationViaDDM_UnchangedDeclarations_TouchCalled(t *testing.T) {
 	err := PushApplicationViaDDM(client, "DEVICE-UDID-1234", app)
 	require.NoError(t, err)
 
-	// When declarations are unchanged (204), touch calls should be made.
+	// When declarations are unchanged (304), touch calls should be made.
 	// Expected: PUT decl (package), POST touch (package), PUT decl (activation),
 	// POST touch (activation), PUT set-decl (package), PUT set-decl (activation),
 	// PUT enrollment-set
@@ -197,8 +197,8 @@ func TestPushApplicationViaDDM_TouchError(t *testing.T) {
 	server, _, statusOverrides := newMockKMFDDM(t)
 	defer server.Close()
 
-	// Declarations return 204 (unchanged) so touch is called
-	statusOverrides["PUT /v1/declarations"] = http.StatusNoContent
+	// Declarations return 304 (unchanged) so touch is called
+	statusOverrides["PUT /v1/declarations"] = http.StatusNotModified
 	// Touch returns 500
 	statusOverrides["POST /v1/declarations/"+testPackageID+"/touch"] = http.StatusInternalServerError
 

--- a/director/ddm_app_push_test.go
+++ b/director/ddm_app_push_test.go
@@ -1,0 +1,211 @@
+package director
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mdmdirector/mdmdirector/ddm"
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testAppUUID    = "550e8400-e29b-41d4-a716-446655440000"
+	testPackageID  = "biz.airbnb.DEVICE-UDID-1234.package.550e8400-e29b-41d4-a716-446655440000"
+	testActiPackID = "biz.airbnb.DEVICE-UDID-1234.package_activation.550e8400-e29b-41d4-a716-446655440000"
+)
+
+func newTestApp(manifestURL string) types.DeviceInstallApplication {
+	return types.DeviceInstallApplication{
+		ID:          uuid.MustParse(testAppUUID),
+		ManifestURL: manifestURL,
+	}
+}
+
+func TestPushApplicationViaDDM_AllNew(t *testing.T) {
+	server, requests, _ := newMockKMFDDM(t)
+	defer server.Close()
+
+	client := ddm.NewKMFDDMClient(server.URL, "testapikey")
+	app := newTestApp("https://example.com/app.plist")
+
+	err := PushApplicationViaDDM(client, "DEVICE-UDID-1234", app)
+	require.NoError(t, err)
+
+	// When declarations are new (304), no touch calls should be made.
+	// Expected sequence: PUT decl (package), PUT decl (activation), PUT set-decl (package),
+	// PUT set-decl (activation), PUT enrollment-set
+	assert.Len(t, *requests, 5)
+
+	reqs := *requests
+
+	// Step 1: PUT Package declaration
+	assert.Equal(t, "PUT", reqs[0].Method)
+	assert.Equal(t, "/v1/declarations", reqs[0].Path)
+	assert.Contains(t, reqs[0].Query, "nonotify=true")
+	var packageDecl ddm.Declaration
+	err = json.Unmarshal([]byte(reqs[0].Body), &packageDecl)
+	require.NoError(t, err)
+	assert.Equal(t, testPackageID, packageDecl.Identifier)
+	assert.Equal(t, ddm.TypePackage, packageDecl.Type)
+
+	// Step 2: PUT ActivationSimple declaration
+	assert.Equal(t, "PUT", reqs[1].Method)
+	assert.Equal(t, "/v1/declarations", reqs[1].Path)
+	assert.Contains(t, reqs[1].Query, "nonotify=true")
+	var activationDecl ddm.Declaration
+	err = json.Unmarshal([]byte(reqs[1].Body), &activationDecl)
+	require.NoError(t, err)
+	assert.Equal(t, testActiPackID, activationDecl.Identifier)
+	assert.Equal(t, ddm.TypeActivationSimple, activationDecl.Type)
+
+	// Step 3: PUT set-declaration (package)
+	assert.Equal(t, "PUT", reqs[2].Method)
+	assert.Equal(t, "/v1/set-declarations/DEVICE-UDID-1234", reqs[2].Path)
+	assert.Contains(t, reqs[2].Query, "declaration="+testPackageID)
+	assert.Contains(t, reqs[2].Query, "nonotify=true")
+
+	// Step 4: PUT set-declaration (activation)
+	assert.Equal(t, "PUT", reqs[3].Method)
+	assert.Equal(t, "/v1/set-declarations/DEVICE-UDID-1234", reqs[3].Path)
+	assert.Contains(t, reqs[3].Query, "declaration="+testActiPackID)
+	assert.Contains(t, reqs[3].Query, "nonotify=true")
+
+	// Step 5: PUT enrollment-set (noNotify=false to trigger sync)
+	assert.Equal(t, "PUT", reqs[4].Method)
+	assert.Equal(t, "/v1/enrollment-sets/DEVICE-UDID-1234", reqs[4].Path)
+	assert.Contains(t, reqs[4].Query, "set=DEVICE-UDID-1234")
+	assert.NotContains(t, reqs[4].Query, "nonotify=true")
+}
+
+func TestPushApplicationViaDDM_UnchangedDeclarations_TouchCalled(t *testing.T) {
+	server, requests, statusOverrides := newMockKMFDDM(t)
+	defer server.Close()
+
+	// Override PUT declarations to return 204 (unchanged)
+	statusOverrides["PUT /v1/declarations"] = http.StatusNoContent
+
+	client := ddm.NewKMFDDMClient(server.URL, "testapikey")
+	app := newTestApp("https://example.com/app.plist")
+
+	err := PushApplicationViaDDM(client, "DEVICE-UDID-1234", app)
+	require.NoError(t, err)
+
+	// When declarations are unchanged (204), touch calls should be made.
+	// Expected: PUT decl (package), POST touch (package), PUT decl (activation),
+	// POST touch (activation), PUT set-decl (package), PUT set-decl (activation),
+	// PUT enrollment-set
+	assert.Len(t, *requests, 7)
+
+	reqs := *requests
+
+	// Step 1: PUT Package declaration (returns 204 = unchanged)
+	assert.Equal(t, "PUT", reqs[0].Method)
+	assert.Equal(t, "/v1/declarations", reqs[0].Path)
+
+	// Step 1b: POST touch for Package
+	assert.Equal(t, "POST", reqs[1].Method)
+	assert.Equal(t, "/v1/declarations/"+testPackageID+"/touch", reqs[1].Path)
+	assert.Contains(t, reqs[1].Query, "nonotify=true")
+
+	// Step 2: PUT ActivationSimple declaration (returns 204 = unchanged)
+	assert.Equal(t, "PUT", reqs[2].Method)
+	assert.Equal(t, "/v1/declarations", reqs[2].Path)
+
+	// Step 2b: POST touch for ActivationSimple
+	assert.Equal(t, "POST", reqs[3].Method)
+	assert.Equal(t, "/v1/declarations/"+testActiPackID+"/touch", reqs[3].Path)
+	assert.Contains(t, reqs[3].Query, "nonotify=true")
+
+	// Step 3-4: PUT set-declarations
+	assert.Equal(t, "PUT", reqs[4].Method)
+	assert.Equal(t, "/v1/set-declarations/DEVICE-UDID-1234", reqs[4].Path)
+
+	assert.Equal(t, "PUT", reqs[5].Method)
+	assert.Equal(t, "/v1/set-declarations/DEVICE-UDID-1234", reqs[5].Path)
+
+	// Step 5: PUT enrollment-set
+	assert.Equal(t, "PUT", reqs[6].Method)
+	assert.Equal(t, "/v1/enrollment-sets/DEVICE-UDID-1234", reqs[6].Path)
+}
+
+func TestPushApplicationViaDDM_ActivationReferencesPackageDeclaration(t *testing.T) {
+	server, requests, _ := newMockKMFDDM(t)
+	defer server.Close()
+
+	client := ddm.NewKMFDDMClient(server.URL, "testapikey")
+	app := newTestApp("https://example.com/app.plist")
+
+	err := PushApplicationViaDDM(client, "DEVICE-UDID-1234", app)
+	require.NoError(t, err)
+
+	reqs := *requests
+	// Parse the activation declaration to verify it references the package declaration
+	var activationDecl struct {
+		Identifier string `json:"Identifier"`
+		Payload    struct {
+			StandardConfigurations []string `json:"StandardConfigurations"`
+		} `json:"Payload"`
+	}
+	err = json.Unmarshal([]byte(reqs[1].Body), &activationDecl)
+	require.NoError(t, err)
+
+	assert.Len(t, activationDecl.Payload.StandardConfigurations, 1)
+	assert.Equal(t, testPackageID, activationDecl.Payload.StandardConfigurations[0])
+}
+
+func TestPushApplicationViaDDM_PackagePayloadContainsManifestURL(t *testing.T) {
+	server, requests, _ := newMockKMFDDM(t)
+	defer server.Close()
+
+	client := ddm.NewKMFDDMClient(server.URL, "testapikey")
+	app := newTestApp("https://example.com/myapp.plist")
+
+	err := PushApplicationViaDDM(client, "DEVICE-UDID-1234", app)
+	require.NoError(t, err)
+
+	reqs := *requests
+	// Parse the package declaration to verify it contains the manifest URL
+	var payload struct {
+		Payload struct {
+			ManifestURL string `json:"ManifestURL"`
+		} `json:"Payload"`
+	}
+	err = json.Unmarshal([]byte(reqs[0].Body), &payload)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/myapp.plist", payload.Payload.ManifestURL)
+}
+
+func TestPushApplicationViaDDM_PutDeclarationError(t *testing.T) {
+	server, _, statusOverrides := newMockKMFDDM(t)
+	defer server.Close()
+
+	statusOverrides["PUT /v1/declarations"] = http.StatusInternalServerError
+
+	client := ddm.NewKMFDDMClient(server.URL, "testapikey")
+	app := newTestApp("https://example.com/app.plist")
+
+	err := PushApplicationViaDDM(client, "DEVICE-UDID-1234", app)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PUT Package declaration")
+}
+
+func TestPushApplicationViaDDM_TouchError(t *testing.T) {
+	server, _, statusOverrides := newMockKMFDDM(t)
+	defer server.Close()
+
+	// Declarations return 204 (unchanged) so touch is called
+	statusOverrides["PUT /v1/declarations"] = http.StatusNoContent
+	// Touch returns 500
+	statusOverrides["POST /v1/declarations/"+testPackageID+"/touch"] = http.StatusInternalServerError
+
+	client := ddm.NewKMFDDMClient(server.URL, "testapikey")
+	app := newTestApp("https://example.com/app.plist")
+
+	err := PushApplicationViaDDM(client, "DEVICE-UDID-1234", app)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "touch Package declaration")
+}

--- a/director/ddm_app_push_test.go
+++ b/director/ddm_app_push_test.go
@@ -14,8 +14,8 @@ import (
 
 const (
 	testAppUUID    = "550e8400-e29b-41d4-a716-446655440000"
-	testPackageID  = "biz.airbnb.DEVICE-UDID-1234.package.550e8400-e29b-41d4-a716-446655440000"
-	testActiPackID = "biz.airbnb.DEVICE-UDID-1234.package_activation.550e8400-e29b-41d4-a716-446655440000"
+	testPackageID  = "com.example.DEVICE-UDID-1234.package.550e8400-e29b-41d4-a716-446655440000"
+	testActiPackID = "com.example.DEVICE-UDID-1234.package_activation.550e8400-e29b-41d4-a716-446655440000"
 )
 
 func newTestApp(manifestURL string) types.DeviceInstallApplication {

--- a/director/ddm_push.go
+++ b/director/ddm_push.go
@@ -13,7 +13,7 @@ import (
 func PushProfileViaDDM(client *ddm.KMFDDMClient, udid string, payloadIdentifier string, nanoMDMURL string) error {
 	declarationPrefix := utils.DDMDeclarationPrefix()
 	legacyDeclID := ddm.LegacyProfileDeclarationID(declarationPrefix, udid, payloadIdentifier)
-	activationDeclID := ddm.ActivationDeclarationID(declarationPrefix, udid, payloadIdentifier)
+	activationDeclID := ddm.ProfileActivationDeclarationID(declarationPrefix, udid, payloadIdentifier)
 	profileURL := ddm.ProfileDownloadURL(nanoMDMURL, udid, payloadIdentifier)
 
 	// Step 1: PUT LegacyProfile declaration (noNotify=true)
@@ -185,7 +185,7 @@ func PushSharedProfilesViaDDM(devices []types.Device, profiles []types.SharedPro
 func DeleteProfileViaDDM(client *ddm.KMFDDMClient, udid string, payloadIdentifier string) error {
 	declarationPrefix := utils.DDMDeclarationPrefix()
 	legacyDeclID := ddm.LegacyProfileDeclarationID(declarationPrefix, udid, payloadIdentifier)
-	activationDeclID := ddm.ActivationDeclarationID(declarationPrefix, udid, payloadIdentifier)
+	activationDeclID := ddm.ProfileActivationDeclarationID(declarationPrefix, udid, payloadIdentifier)
 
 	// Step 1: Remove LegacyProfile from the device's set (noNotify=true)
 	if err := client.DeleteSetDeclaration(udid, legacyDeclID, true); err != nil {

--- a/director/ddm_push.go
+++ b/director/ddm_push.go
@@ -29,7 +29,7 @@ func PushProfileViaDDM(client *ddm.KMFDDMClient, udid string, payloadIdentifier 
 		return errors.Wrapf(err, "PushProfileViaDDM: PUT LegacyProfile declaration for %s on %s", payloadIdentifier, udid)
 	}
 
-	// If unchanged (204), touch to force reinstall
+	// If unchanged (304), touch to force reinstall
 	if !legacyChanged {
 		if err := client.TouchDeclaration(legacyDeclID, true); err != nil {
 			return errors.Wrapf(err, "PushProfileViaDDM: touch LegacyProfile declaration for %s on %s", payloadIdentifier, udid)
@@ -50,7 +50,7 @@ func PushProfileViaDDM(client *ddm.KMFDDMClient, udid string, payloadIdentifier 
 		return errors.Wrapf(err, "PushProfileViaDDM: PUT ActivationSimple declaration for %s on %s", payloadIdentifier, udid)
 	}
 
-	// If unchanged (204), touch to force reinstall
+	// If unchanged (304), touch to force reinstall
 	if !activationChanged {
 		if err := client.TouchDeclaration(activationDeclID, true); err != nil {
 			return errors.Wrapf(err, "PushProfileViaDDM: touch ActivationSimple declaration for %s on %s", payloadIdentifier, udid)

--- a/director/ddm_push.go
+++ b/director/ddm_push.go
@@ -12,7 +12,7 @@ import (
 // PushProfileViaDDM pushes a single profile via DDM declarations
 func PushProfileViaDDM(client *ddm.KMFDDMClient, udid string, payloadIdentifier string, nanoMDMURL string) error {
 	legacyDeclID := ddm.LegacyProfileDeclarationID(udid, payloadIdentifier)
-	activationDeclID := ddm.ActivationDeclarationID(udid, payloadIdentifier)
+	activationDeclID := ddm.ProfileActivationDeclarationID(udid, payloadIdentifier)
 	profileURL := ddm.ProfileDownloadURL(nanoMDMURL, udid, payloadIdentifier)
 
 	// Step 1: PUT LegacyProfile declaration (noNotify=true)
@@ -183,7 +183,7 @@ func PushSharedProfilesViaDDM(devices []types.Device, profiles []types.SharedPro
 // DeleteProfileViaDDM removes a single profile's DDM declarations for a device
 func DeleteProfileViaDDM(client *ddm.KMFDDMClient, udid string, payloadIdentifier string) error {
 	legacyDeclID := ddm.LegacyProfileDeclarationID(udid, payloadIdentifier)
-	activationDeclID := ddm.ActivationDeclarationID(udid, payloadIdentifier)
+	activationDeclID := ddm.ProfileActivationDeclarationID(udid, payloadIdentifier)
 
 	// Step 1: Remove LegacyProfile from the device's set (noNotify=true)
 	if err := client.DeleteSetDeclaration(udid, legacyDeclID, true); err != nil {

--- a/director/ddm_push_test.go
+++ b/director/ddm_push_test.go
@@ -230,34 +230,6 @@ func TestPushProfileViaDDM_TouchError(t *testing.T) {
 	assert.Contains(t, err.Error(), "touch LegacyProfile declaration")
 }
 
-func TestPushProfileViaDDM_SpecialCharactersInPayloadIdentifier(t *testing.T) {
-	server, requests, _ := newMockKMFDDM(t)
-	defer server.Close()
-
-	client := ddm.NewKMFDDMClient(server.URL, "testapikey")
-
-	err := PushProfileViaDDM(client, "DEVICE-UDID-1234", "com.example.profile with spaces!", "https://mdm.example.com")
-	require.NoError(t, err)
-
-	reqs := *requests
-	// The declaration ID should use the sanitized profile ID
-	var legacyDecl ddm.Declaration
-	err = json.Unmarshal([]byte(reqs[0].Body), &legacyDecl)
-	require.NoError(t, err)
-	// Spaces and ! replaced with underscores
-	assert.Equal(t, "biz.airbnb.DEVICE-UDID-1234.legacy_profile.com.example.profile_with_spaces_", legacyDecl.Identifier)
-
-	// But the ProfileURL should use the original payload identifier
-	var payload struct {
-		Payload struct {
-			ProfileURL string `json:"ProfileURL"`
-		} `json:"Payload"`
-	}
-	err = json.Unmarshal([]byte(reqs[0].Body), &payload)
-	require.NoError(t, err)
-	assert.Contains(t, payload.Payload.ProfileURL, "com.example.profile with spaces!")
-}
-
 func TestDeleteProfileViaDDM_Success(t *testing.T) {
 	server, requests, _ := newMockKMFDDM(t)
 	defer server.Close()

--- a/director/ddm_push_test.go
+++ b/director/ddm_push_test.go
@@ -59,8 +59,8 @@ func newMockKMFDDM(t *testing.T) (*httptest.Server, *[]requestLog, map[string]in
 		// Default responses
 		switch {
 		case r.Method == "PUT" && r.URL.Path == "/v1/declarations":
-			// 304 = changed/new in KMFDDM
-			w.WriteHeader(http.StatusNotModified)
+			// 204 = changed/new in KMFDDM
+			w.WriteHeader(http.StatusNoContent)
 		default:
 			// 204 for touch, set-declarations, enrollment-sets
 			w.WriteHeader(http.StatusNoContent)
@@ -130,15 +130,15 @@ func TestPushProfileViaDDM_UnchangedDeclarations_TouchCalled(t *testing.T) {
 	server, requests, statusOverrides := newMockKMFDDM(t)
 	defer server.Close()
 
-	// Override PUT declarations to return 204 (unchanged)
-	statusOverrides["PUT /v1/declarations"] = http.StatusNoContent
+	// Override PUT declarations to return 304 (unchanged)
+	statusOverrides["PUT /v1/declarations"] = http.StatusNotModified
 
 	client := ddm.NewKMFDDMClient(server.URL, "testapikey")
 
 	err := PushProfileViaDDM(client, "DEVICE-UDID-1234", "com.example.wifi", "https://mdm.example.com")
 	require.NoError(t, err)
 
-	// When declarations are unchanged (204), touch calls should be made.
+	// When declarations are unchanged (304), touch calls should be made.
 	// Expected: PUT decl (legacy), POST touch (legacy), PUT decl (activation),
 	// POST touch (activation), PUT set-decl (legacy), PUT set-decl (activation),
 	// PUT enrollment-set
@@ -218,8 +218,8 @@ func TestPushProfileViaDDM_TouchError(t *testing.T) {
 	server, _, statusOverrides := newMockKMFDDM(t)
 	defer server.Close()
 
-	// Declarations return 204 (unchanged) so touch is called
-	statusOverrides["PUT /v1/declarations"] = http.StatusNoContent
+	// Declarations return 304 (unchanged) so touch is called
+	statusOverrides["PUT /v1/declarations"] = http.StatusNotModified
 	// Touch returns 500
 	statusOverrides["POST /v1/declarations/biz.airbnb.DEVICE-UDID-1234.legacy_profile.com.example.wifi/touch"] = http.StatusInternalServerError
 

--- a/director/ddm_push_test.go
+++ b/director/ddm_push_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	flag.String("ddm-declaration-prefix", "biz.airbnb", "DDM declaration prefix")
+	flag.String("ddm-declaration-prefix", "com.example", "DDM declaration prefix")
 	os.Exit(m.Run())
 }
 
@@ -100,7 +100,7 @@ func TestPushProfileViaDDM_AllNew(t *testing.T) {
 	var legacyDecl ddm.Declaration
 	err = json.Unmarshal([]byte(reqs[0].Body), &legacyDecl)
 	require.NoError(t, err)
-	assert.Equal(t, "biz.airbnb.DEVICE-UDID-1234.legacy_profile.com.example.wifi", legacyDecl.Identifier)
+	assert.Equal(t, "com.example.DEVICE-UDID-1234.legacy_profile.com.example.wifi", legacyDecl.Identifier)
 	assert.Equal(t, ddm.TypeLegacyProfile, legacyDecl.Type)
 
 	// Step 2: PUT ActivationSimple declaration
@@ -110,19 +110,19 @@ func TestPushProfileViaDDM_AllNew(t *testing.T) {
 	var activationDecl ddm.Declaration
 	err = json.Unmarshal([]byte(reqs[1].Body), &activationDecl)
 	require.NoError(t, err)
-	assert.Equal(t, "biz.airbnb.DEVICE-UDID-1234.legacy_profile_activation.com.example.wifi", activationDecl.Identifier)
+	assert.Equal(t, "com.example.DEVICE-UDID-1234.legacy_profile_activation.com.example.wifi", activationDecl.Identifier)
 	assert.Equal(t, ddm.TypeActivationSimple, activationDecl.Type)
 
 	// Step 3: PUT set-declaration (legacy)
 	assert.Equal(t, "PUT", reqs[2].Method)
 	assert.Equal(t, "/v1/set-declarations/DEVICE-UDID-1234", reqs[2].Path)
-	assert.Contains(t, reqs[2].Query, "declaration=biz.airbnb.DEVICE-UDID-1234.legacy_profile.com.example.wifi")
+	assert.Contains(t, reqs[2].Query, "declaration=com.example.DEVICE-UDID-1234.legacy_profile.com.example.wifi")
 	assert.Contains(t, reqs[2].Query, "nonotify=true")
 
 	// Step 4: PUT set-declaration (activation)
 	assert.Equal(t, "PUT", reqs[3].Method)
 	assert.Equal(t, "/v1/set-declarations/DEVICE-UDID-1234", reqs[3].Path)
-	assert.Contains(t, reqs[3].Query, "declaration=biz.airbnb.DEVICE-UDID-1234.legacy_profile_activation.com.example.wifi")
+	assert.Contains(t, reqs[3].Query, "declaration=com.example.DEVICE-UDID-1234.legacy_profile_activation.com.example.wifi")
 	assert.Contains(t, reqs[3].Query, "nonotify=true")
 
 	// Step 5: PUT enrollment-set (noNotify=false to trigger sync)
@@ -159,7 +159,7 @@ func TestPushProfileViaDDM_UnchangedDeclarations_TouchCalled(t *testing.T) {
 
 	// Step 1b: POST touch for LegacyProfile
 	assert.Equal(t, "POST", reqs[1].Method)
-	assert.Equal(t, "/v1/declarations/biz.airbnb.DEVICE-UDID-1234.legacy_profile.com.example.wifi/touch", reqs[1].Path)
+	assert.Equal(t, "/v1/declarations/com.example.DEVICE-UDID-1234.legacy_profile.com.example.wifi/touch", reqs[1].Path)
 	assert.Contains(t, reqs[1].Query, "nonotify=true")
 
 	// Step 2: PUT ActivationSimple declaration (returns 304 = unchanged)
@@ -168,7 +168,7 @@ func TestPushProfileViaDDM_UnchangedDeclarations_TouchCalled(t *testing.T) {
 
 	// Step 2b: POST touch for ActivationSimple
 	assert.Equal(t, "POST", reqs[3].Method)
-	assert.Equal(t, "/v1/declarations/biz.airbnb.DEVICE-UDID-1234.legacy_profile_activation.com.example.wifi/touch", reqs[3].Path)
+	assert.Equal(t, "/v1/declarations/com.example.DEVICE-UDID-1234.legacy_profile_activation.com.example.wifi/touch", reqs[3].Path)
 	assert.Contains(t, reqs[3].Query, "nonotify=true")
 
 	// Step 3-4: PUT set-declarations
@@ -203,7 +203,7 @@ func TestPushProfileViaDDM_ActivationReferencesLegacyDeclaration(t *testing.T) {
 	err = json.Unmarshal([]byte(reqs[1].Body), &activationDecl)
 	require.NoError(t, err)
 
-	expectedLegacyID := "biz.airbnb.DEVICE-UDID-1234.legacy_profile.com.example.wifi"
+	expectedLegacyID := "com.example.DEVICE-UDID-1234.legacy_profile.com.example.wifi"
 	assert.Len(t, activationDecl.Payload.StandardConfigurations, 1)
 	assert.Equal(t, expectedLegacyID, activationDecl.Payload.StandardConfigurations[0])
 }
@@ -228,7 +228,7 @@ func TestPushProfileViaDDM_TouchError(t *testing.T) {
 	// Declarations return 304 (unchanged) so touch is called
 	statusOverrides["PUT /v1/declarations"] = http.StatusNotModified
 	// Touch returns 500
-	statusOverrides["POST /v1/declarations/biz.airbnb.DEVICE-UDID-1234.legacy_profile.com.example.wifi/touch"] = http.StatusInternalServerError
+	statusOverrides["POST /v1/declarations/com.example.DEVICE-UDID-1234.legacy_profile.com.example.wifi/touch"] = http.StatusInternalServerError
 
 	client := ddm.NewKMFDDMClient(server.URL, "testapikey")
 
@@ -253,23 +253,23 @@ func TestDeleteProfileViaDDM_Success(t *testing.T) {
 	// Step 1: DELETE set-declaration for LegacyProfile
 	assert.Equal(t, "DELETE", reqs[0].Method)
 	assert.Equal(t, "/v1/set-declarations/DEVICE-UDID-1234", reqs[0].Path)
-	assert.Contains(t, reqs[0].Query, "declaration=biz.airbnb.DEVICE-UDID-1234.legacy_profile.com.example.wifi")
+	assert.Contains(t, reqs[0].Query, "declaration=com.example.DEVICE-UDID-1234.legacy_profile.com.example.wifi")
 	assert.Contains(t, reqs[0].Query, "nonotify=true")
 
 	// Step 2: DELETE set-declaration for ActivationSimple
 	assert.Equal(t, "DELETE", reqs[1].Method)
 	assert.Equal(t, "/v1/set-declarations/DEVICE-UDID-1234", reqs[1].Path)
-	assert.Contains(t, reqs[1].Query, "declaration=biz.airbnb.DEVICE-UDID-1234.legacy_profile_activation.com.example.wifi")
+	assert.Contains(t, reqs[1].Query, "declaration=com.example.DEVICE-UDID-1234.legacy_profile_activation.com.example.wifi")
 	assert.Contains(t, reqs[1].Query, "nonotify=true")
 
 	// Step 3: DELETE declaration (legacy)
 	assert.Equal(t, "DELETE", reqs[2].Method)
-	assert.Equal(t, "/v1/declarations/biz.airbnb.DEVICE-UDID-1234.legacy_profile.com.example.wifi", reqs[2].Path)
+	assert.Equal(t, "/v1/declarations/com.example.DEVICE-UDID-1234.legacy_profile.com.example.wifi", reqs[2].Path)
 	assert.Contains(t, reqs[2].Query, "nonotify=true")
 
 	// Step 4: DELETE declaration (activation)
 	assert.Equal(t, "DELETE", reqs[3].Method)
-	assert.Equal(t, "/v1/declarations/biz.airbnb.DEVICE-UDID-1234.legacy_profile_activation.com.example.wifi", reqs[3].Path)
+	assert.Equal(t, "/v1/declarations/com.example.DEVICE-UDID-1234.legacy_profile_activation.com.example.wifi", reqs[3].Path)
 	assert.Contains(t, reqs[3].Query, "nonotify=true")
 
 	// Step 5: PUT enrollment-set (noNotify=false to trigger sync)

--- a/director/device.go
+++ b/director/device.go
@@ -21,7 +21,7 @@ func UpdateDevice(newDevice types.Device) (*types.Device, error) {
 	var device types.Device
 	var oldDevice types.Device
 
-	if newDevice.UDID == "" && device.SerialNumber == "" {
+	if newDevice.UDID == "" && newDevice.SerialNumber == "" {
 		err := fmt.Errorf("no device UDID or serial set")
 		return &newDevice, errors.Wrap(err, "UpdateDevice")
 	}
@@ -57,20 +57,6 @@ func UpdateDevice(newDevice types.Device) (*types.Device, error) {
 	err := UpdateDeviceBools(&newDevice)
 	if err != nil {
 		return &device, errors.Wrap(err, "UpdateDevice")
-	}
-
-	if newDevice.AwaitingConfiguration && newDevice.InitialTasksRun {
-		err := SendDeviceConfigured(newDevice)
-		if err != nil {
-			return &device, errors.Wrap(err, "UpdateDevice:SendDeviceConfigured")
-		}
-	}
-
-	if !newDevice.InitialTasksRun && newDevice.AwaitingConfiguration {
-		err := RunInitialTasks(newDevice.UDID)
-		if err != nil {
-			return &device, errors.Wrap(err, "UpdateDevice:RunInitialTasks")
-		}
 	}
 
 	return &device, nil

--- a/director/install_application.go
+++ b/director/install_application.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 
 	"github.com/mdmdirector/mdmdirector/db"
+	"github.com/mdmdirector/mdmdirector/ddm"
 	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/mdmdirector/mdmdirector/utils"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -140,6 +142,10 @@ func SaveInstallApplications(devices []types.Device, payload types.InstallApplic
 }
 
 func PushInstallApplication(devices []types.Device, installApplication types.DeviceInstallApplication) ([]types.Command, error) {
+	if utils.UseDDMPackages() {
+		return nil, PushApplicationsViaDDM(devices, installApplication.ManifestURL)
+	}
+
 	var sentCommands []types.Command
 	for i := range devices {
 		device := devices[i]
@@ -190,6 +196,10 @@ func SaveSharedInstallApplications(payload types.InstallApplicationPayload) erro
 }
 
 func PushSharedInstallApplication(devices []types.Device, installSharedApplication types.SharedInstallApplication) ([]types.Command, error) {
+	if utils.UseDDMPackages() {
+		return nil, PushSharedApplicationsViaDDM(devices, installSharedApplication.ManifestURL)
+	}
+
 	var sentCommands []types.Command
 	for i := range devices {
 		device := devices[i]
@@ -216,6 +226,10 @@ func PushSharedInstallApplication(devices []types.Device, installSharedApplicati
 }
 
 func InstallBootstrapPackages(device types.Device) ([]types.Command, error) {
+	if utils.UseDDMPackages() {
+		return nil, installBootstrapPackagesViaDDM(device)
+	}
+
 	var sharedInstallApplication types.SharedInstallApplication
 	var deviceInstallApplication types.DeviceInstallApplication
 	var sharedInstallApplications []types.SharedInstallApplication
@@ -258,6 +272,43 @@ func InstallBootstrapPackages(device types.Device) ([]types.Command, error) {
 	}
 
 	return sentCommands, nil
+}
+
+func installBootstrapPackagesViaDDM(device types.Device) error {
+	client, err := ddm.Client()
+	if err != nil {
+		return err
+	}
+
+	var sharedInstallApplications []types.SharedInstallApplication
+	if err := db.DB.Find(&sharedInstallApplications).Error; err != nil {
+		return errors.Wrap(err, "installBootstrapPackagesViaDDM: querying shared apps")
+	}
+
+	for _, sharedApp := range sharedInstallApplications {
+		log.Debugf("InstallApplication via DDM (shared): %v", sharedApp)
+		app := types.DeviceInstallApplication{
+			ID:          sharedApp.ID,
+			ManifestURL: sharedApp.ManifestURL,
+		}
+		if err := PushApplicationViaDDM(client, device.UDID, app); err != nil {
+			return errors.Wrapf(err, "installBootstrapPackagesViaDDM: pushing shared app %s", sharedApp.ManifestURL)
+		}
+	}
+
+	var deviceInstallApplications []types.DeviceInstallApplication
+	if err := db.DB.Where("device_ud_id = ?", device.UDID).Find(&deviceInstallApplications).Error; err != nil {
+		return errors.Wrap(err, "installBootstrapPackagesViaDDM: querying device apps")
+	}
+
+	for _, app := range deviceInstallApplications {
+		log.Debugf("InstallApplication via DDM (device): %v", app)
+		if err := PushApplicationViaDDM(client, device.UDID, app); err != nil {
+			return errors.Wrapf(err, "installBootstrapPackagesViaDDM: pushing device app %s", app.ManifestURL)
+		}
+	}
+
+	return nil
 }
 
 func GetSharedApplicationss(w http.ResponseWriter, r *http.Request) {

--- a/director/webhook.go
+++ b/director/webhook.go
@@ -59,6 +59,29 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// reconcileDeviceState handles post-enrollment lifecycle transitions after any device event
+// Returns (true, nil) if RunInitialTasks was triggered — caller must return immediately
+// Returns (false, err) if SendDeviceConfigured failed — caller must propagate the error
+func reconcileDeviceState(device types.Device, currentDevice *types.Device) (bool, error) {
+	if !currentDevice.InitialTasksRun && currentDevice.TokenUpdateRecieved {
+		InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Running initial tasks"})
+		if err := RunInitialTasks(device.UDID); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			return true, err
+		}
+		return true, nil
+	}
+
+	if currentDevice.AwaitingConfiguration && currentDevice.InitialTasksRun {
+		if err := SendDeviceConfigured(*currentDevice); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
 func handleCheckinEvent(topic string, event *types.CheckinEvent) error {
 	var device types.Device
 	if err := plist.Unmarshal(event.RawPayload, &device); err != nil {
@@ -95,20 +118,8 @@ func handleCheckinEvent(topic string, event *types.CheckinEvent) error {
 		return err
 	}
 
-	if !currentDevice.InitialTasksRun && currentDevice.TokenUpdateRecieved {
-		InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Running initial tasks"})
-		if err := RunInitialTasks(device.UDID); err != nil {
-			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
-			return err
-		}
-		return nil
-	}
-
-	if currentDevice.AwaitingConfiguration && currentDevice.InitialTasksRun {
-		if err := SendDeviceConfigured(*currentDevice); err != nil {
-			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
-			return err
-		}
+	if done, err := reconcileDeviceState(device, currentDevice); done || err != nil {
+		return err
 	}
 
 	if utils.PushOnNewBuild() {
@@ -134,9 +145,22 @@ func handleAcknowledgeEvent(event *types.AcknowledgeEvent) error {
 	}
 
 	device.Active = true
-	if _, err := UpdateDevice(device); err != nil {
+	currentDevice, err := UpdateDevice(device)
+	if err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
 		return err
+	}
+
+	if done, err := reconcileDeviceState(device, currentDevice); done || err != nil {
+		return err
+	}
+
+	oldBuild := device.BuildVersion
+	if utils.PushOnNewBuild() {
+		if err := pushOnNewBuild(device.UDID, oldBuild); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			return err
+		}
 	}
 
 	if event.CommandUUID != "" {

--- a/director/webhook.go
+++ b/director/webhook.go
@@ -40,194 +40,179 @@ func profileListDataJSON(profileListData types.ProfileListData) ([]byte, error) 
 
 func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 	var out types.PostPayload
-
-	err := json.NewDecoder(r.Body).Decode(&out)
-	if err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&out); err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
+		return
 	}
-
-	var device types.Device
 
 	if out.CheckinEvent != nil {
-		err = plist.Unmarshal(out.CheckinEvent.RawPayload, &device)
-		if err != nil {
-			ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-		}
-	} else if out.AcknowledgeEvent != nil {
-		err = plist.Unmarshal(out.AcknowledgeEvent.RawPayload, &device)
-		if err != nil {
-			ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-		}
-	}
-
-	if out.Topic == "mdm.CheckOut" {
-		err = ResetDevice(device)
-		if err != nil {
-			ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-		}
-	} else {
-		device.Active = true
-	}
-
-	switch out.Topic {
-	case "mdm.Authenticate":
-		err = ResetDevice(device)
-		if err != nil {
-			ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-		}
-	case "mdm.TokenUpdate":
-		tokenUpdateDevice, err := SetTokenUpdate(device)
-		if err != nil {
-			ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-		}
-
-		if !tokenUpdateDevice.InitialTasksRun {
-			_, err := UpdateDevice(device)
-			if err != nil {
-				ErrorLogger(LogHolder{Message: err.Error()})
-			}
-			InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Running initial tasks due to device update"})
-			err = RunInitialTasks(device.UDID)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-			}
-			return
-		}
-	}
-	oldUDID := device.UDID
-	oldBuild := device.BuildVersion
-	if device.UDID == "" {
-		log.Error(out)
-		log.Fatal("No device UDID set")
-	}
-	updatedDevice, err := UpdateDevice(device)
-	if err != nil {
-		ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-	}
-
-	if !updatedDevice.InitialTasksRun && updatedDevice.TokenUpdateRecieved {
-		InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Running initial tasks due to device update"})
-		err = RunInitialTasks(device.UDID)
-		if err != nil {
-			ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
+		if err := handleCheckinEvent(out.Topic, out.CheckinEvent); err != nil {
+			ErrorLogger(LogHolder{Message: err.Error()})
 		}
 		return
 	}
 
-	if utils.PushOnNewBuild() {
-		err = pushOnNewBuild(oldUDID, oldBuild)
-		if err != nil {
-			ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-		}
-	}
-
 	if out.AcknowledgeEvent != nil {
-
-		var payloadDict map[string]interface{}
-		err = plist.Unmarshal(out.AcknowledgeEvent.RawPayload, &payloadDict)
-		if err != nil {
-			ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-		}
-
-		if out.AcknowledgeEvent.CommandUUID != "" {
-			err = UpdateCommand(out.AcknowledgeEvent, device, payloadDict)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-			}
-		}
-
-		if out.AcknowledgeEvent.Status == "Idle" {
-			RequestDeviceUpdate(device)
-			return
-		}
-
-		// Is this a ProfileList response?
-		_, ok := payloadDict["ProfileList"]
-		if ok {
-			lh := LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Received ProfileList payload"}
-			InfoLogger(lh)
-			var profileListData types.ProfileListData
-			err = plist.Unmarshal(out.AcknowledgeEvent.RawPayload, &profileListData)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-				return
-			}
-			jsonBlob, err := profileListDataJSON(profileListData)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-			} else {
-				DebugLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "ProfileList Data", Metric: string(jsonBlob)})
-			}
-
-			err = VerifyMDMProfiles(profileListData, device)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-			}
-
-			if err == nil {
-				plErr := device.UpdateLastProfileList()
-				if plErr != nil {
-					ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: plErr.Error()})
-				}
-			}
-		}
-
-		_, ok = payloadDict["SecurityInfo"]
-		if ok {
-			InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Received SecurityInfo payload"})
-			var securityInfoData types.SecurityInfoData
-			err = plist.Unmarshal(out.AcknowledgeEvent.RawPayload, &securityInfoData)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-			}
-			err = SaveSecurityInfo(securityInfoData, device)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-			}
-		}
-
-		_, ok = payloadDict["CertificateList"]
-		if ok {
-			var certificateListData types.CertificateListData
-			InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Received CertificateList payload"})
-			err = plist.Unmarshal(out.AcknowledgeEvent.RawPayload, &certificateListData)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-			}
-			err = processCertificateList(certificateListData, device)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-			}
-
-			if err == nil {
-				clErr := device.UpdateLastCertificateList()
-				if clErr != nil {
-					ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: clErr.Error()})
-				}
-			}
-		}
-
-		_, ok = payloadDict["QueryResponses"]
-		if ok {
-			InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Received DeviceInformation.QueryResponses payload"})
-			var deviceInformationQueryResponses types.DeviceInformationQueryResponses
-			err = plist.Unmarshal(out.AcknowledgeEvent.RawPayload, &deviceInformationQueryResponses)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-			}
-			_, err = UpdateDevice(deviceInformationQueryResponses.QueryResponses)
-			if err != nil {
-				ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
-			}
-
-			if err == nil {
-				diErr := device.UpdateLastDeviceInfo()
-				if diErr != nil {
-					ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: diErr.Error()})
-				}
-			}
+		if err := handleAcknowledgeEvent(out.AcknowledgeEvent); err != nil {
+			ErrorLogger(LogHolder{Message: err.Error()})
 		}
 	}
+}
+
+func handleCheckinEvent(topic string, event *types.CheckinEvent) error {
+	var device types.Device
+	if err := plist.Unmarshal(event.RawPayload, &device); err != nil {
+		return errors.Wrap(err, "handleCheckinEvent:plist.Unmarshal")
+	}
+
+	if topic == "mdm.CheckOut" {
+		if err := ResetDevice(device); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			return err
+		}
+		return nil
+	}
+
+	device.Active = true
+	oldBuild := device.BuildVersion
+
+	switch topic {
+	case "mdm.Authenticate":
+		if err := ResetDevice(device); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			return err
+		}
+	case "mdm.TokenUpdate":
+		if _, err := SetTokenUpdate(device); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			return err
+		}
+	}
+
+	currentDevice, err := UpdateDevice(device)
+	if err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+		return err
+	}
+
+	if !currentDevice.InitialTasksRun && currentDevice.TokenUpdateRecieved {
+		InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Running initial tasks"})
+		if err := RunInitialTasks(device.UDID); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			return err
+		}
+		return nil
+	}
+
+	if currentDevice.AwaitingConfiguration && currentDevice.InitialTasksRun {
+		if err := SendDeviceConfigured(*currentDevice); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			return err
+		}
+	}
+
+	if utils.PushOnNewBuild() {
+		if err := pushOnNewBuild(device.UDID, oldBuild); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			return err
+		}
+	}
+
+	return nil
+}
+
+func handleAcknowledgeEvent(event *types.AcknowledgeEvent) error {
+	var device types.Device
+	if err := plist.Unmarshal(event.RawPayload, &device); err != nil {
+		return errors.Wrap(err, "handleAcknowledgeEvent:plist.Unmarshal")
+	}
+
+	var payloadDict map[string]interface{}
+	if err := plist.Unmarshal(event.RawPayload, &payloadDict); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+		return err
+	}
+
+	device.Active = true
+	if _, err := UpdateDevice(device); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+		return err
+	}
+
+	if event.CommandUUID != "" {
+		if err := UpdateCommand(event, device, payloadDict); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			return err
+		}
+	}
+
+	if event.Status == "Idle" {
+		RequestDeviceUpdate(device)
+		return nil
+	}
+
+	if err := processAcknowledgePayload(event, device, payloadDict); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+		return err
+	}
+	return nil
+}
+
+func processAcknowledgePayload(event *types.AcknowledgeEvent, device types.Device, payloadDict map[string]interface{}) error {
+	if _, ok := payloadDict["ProfileList"]; ok {
+		InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Received ProfileList payload"})
+		var profileListData types.ProfileListData
+		if err := plist.Unmarshal(event.RawPayload, &profileListData); err != nil {
+			return errors.Wrap(err, "processAcknowledgePayload:ProfileList:plist.Unmarshal")
+		}
+
+		jsonBlob, err := profileListDataJSON(profileListData)
+		if err != nil {
+			ErrorLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: err.Error()})
+		} else {
+			DebugLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "ProfileList Data", Metric: string(jsonBlob)})
+		}
+
+		if err := VerifyMDMProfiles(profileListData, device); err != nil {
+			return errors.Wrap(err, "processAcknowledgePayload:VerifyMDMProfiles")
+		}
+		return device.UpdateLastProfileList()
+	}
+
+	if _, ok := payloadDict["SecurityInfo"]; ok {
+		InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Received SecurityInfo payload"})
+		var securityInfoData types.SecurityInfoData
+		if err := plist.Unmarshal(event.RawPayload, &securityInfoData); err != nil {
+			return errors.Wrap(err, "processAcknowledgePayload:SecurityInfo:plist.Unmarshal")
+		}
+		return SaveSecurityInfo(securityInfoData, device)
+	}
+
+	if _, ok := payloadDict["CertificateList"]; ok {
+		InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Received CertificateList payload"})
+		var certificateListData types.CertificateListData
+		if err := plist.Unmarshal(event.RawPayload, &certificateListData); err != nil {
+			return errors.Wrap(err, "processAcknowledgePayload:CertificateList:plist.Unmarshal")
+		}
+		if err := processCertificateList(certificateListData, device); err != nil {
+			return errors.Wrap(err, "processAcknowledgePayload:processCertificateList")
+		}
+		return device.UpdateLastCertificateList()
+	}
+
+	if _, ok := payloadDict["QueryResponses"]; ok {
+		InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Received DeviceInformation.QueryResponses payload"})
+		var deviceInformationQueryResponses types.DeviceInformationQueryResponses
+		if err := plist.Unmarshal(event.RawPayload, &deviceInformationQueryResponses); err != nil {
+			return errors.Wrap(err, "processAcknowledgePayload:QueryResponses:plist.Unmarshal")
+		}
+		if _, err := UpdateDevice(deviceInformationQueryResponses.QueryResponses); err != nil {
+			return errors.Wrap(err, "processAcknowledgePayload:UpdateDeviceInfo")
+		}
+		return device.UpdateLastDeviceInfo()
+	}
+
+	return nil
 }
 
 func RequestDeviceUpdate(device types.Device) {

--- a/director/webhook_test.go
+++ b/director/webhook_test.go
@@ -1,0 +1,287 @@
+package director
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/mdmdirector/mdmdirector/db"
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/mdmdirector/mdmdirector/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// A minimal valid device plist payload for tests.
+// Only carries UDID and SerialNumber — enough for most checkin/acknowledge flows.
+const testDevicePlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UDID</key>
+	<string>1234-5678-123456</string>
+	<key>SerialNumber</key>
+	<string>C02ABCDEFGH</string>
+</dict>
+</plist>`
+
+// errDBGoneAway is a sentinel error used in DB failure tests.
+var errDBGoneAway = fmt.Errorf("database has gone away")
+
+// ---- reconcileDeviceState -------------------------------------------------------
+
+// When neither trigger condition is met the function is a clean no-op.
+func TestReconcileDeviceState_NeitherConditionMet(t *testing.T) {
+	device := types.Device{UDID: "1234-5678-123456", SerialNumber: "C02ABCDEFGH"}
+	currentDevice := &types.Device{
+		InitialTasksRun:       true,
+		TokenUpdateRecieved:   true,
+		AwaitingConfiguration: false,
+	}
+
+	done, err := reconcileDeviceState(device, currentDevice)
+
+	assert.False(t, done)
+	assert.NoError(t, err)
+}
+
+// TokenUpdateRecieved=false → RunInitialTasks must NOT be triggered.
+func TestReconcileDeviceState_TokenUpdateNotReceived(t *testing.T) {
+	device := types.Device{UDID: "1234-5678-123456"}
+	currentDevice := &types.Device{
+		InitialTasksRun:     false,
+		TokenUpdateRecieved: false,
+	}
+
+	done, err := reconcileDeviceState(device, currentDevice)
+
+	assert.False(t, done)
+	assert.NoError(t, err)
+}
+
+// InitialTasksRun=true → the first condition is false; RunInitialTasks must NOT be re-triggered.
+func TestReconcileDeviceState_InitialTasksAlreadyRun(t *testing.T) {
+	device := types.Device{UDID: "1234-5678-123456"}
+	currentDevice := &types.Device{
+		InitialTasksRun:     true,
+		TokenUpdateRecieved: true,
+	}
+
+	done, err := reconcileDeviceState(device, currentDevice)
+
+	assert.False(t, done)
+	assert.NoError(t, err)
+}
+
+// AwaitingConfiguration=false → SendDeviceConfigured must NOT be called even when InitialTasksRun=true.
+func TestReconcileDeviceState_NotAwaitingConfiguration(t *testing.T) {
+	device := types.Device{UDID: "1234-5678-123456"}
+	currentDevice := &types.Device{
+		InitialTasksRun:       true,
+		AwaitingConfiguration: false,
+	}
+
+	done, err := reconcileDeviceState(device, currentDevice)
+
+	assert.False(t, done)
+	assert.NoError(t, err)
+}
+
+// ---- WebhookHandler HTTP routing ------------------------------------------------
+
+// Only CheckinEvent is populated — AcknowledgeEvent is nil.
+// WebhookHandler must route to handleCheckinEvent and return 200 regardless of inner errors.
+func TestWebhookHandler_OnlyCheckinEventPopulated(t *testing.T) {
+	payload := types.PostPayload{
+		Topic: "mdm.TokenUpdate",
+		CheckinEvent: &types.CheckinEvent{
+			UDID:       "1234-5678-123456",
+			RawPayload: []byte("invalid plist"),
+		},
+		// AcknowledgeEvent intentionally nil
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	WebhookHandler(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// Only AcknowledgeEvent is populated — CheckinEvent is nil.
+// WebhookHandler must route to handleAcknowledgeEvent and return 200 regardless of inner errors.
+func TestWebhookHandler_OnlyAcknowledgeEventPopulated(t *testing.T) {
+	payload := types.PostPayload{
+		AcknowledgeEvent: &types.AcknowledgeEvent{
+			UDID:       "1234-5678-123456",
+			RawPayload: []byte("invalid plist"),
+		},
+		// CheckinEvent intentionally nil
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	WebhookHandler(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// ---- handleCheckinEvent ---------------------------------------------------------
+
+func TestHandleCheckinEvent_InvalidPlist(t *testing.T) {
+	event := &types.CheckinEvent{
+		RawPayload: []byte("not valid plist data"),
+	}
+
+	err := handleCheckinEvent("mdm.TokenUpdate", event)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "handleCheckinEvent:plist.Unmarshal")
+}
+
+// mdm.CheckOut resets the device and returns immediately — no UpdateDevice call.
+func TestHandleCheckinEvent_CheckOut_ResetsDeviceAndReturnsEarly(t *testing.T) {
+	utils.FlagProvider = mockFlagBuilder{false}
+
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	// ClearCommands: DELETE pending commands
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`^DELETE FROM "commands" WHERE device_ud_id = \$1 AND NOT \(status = \$2 OR status = \$3\)`).
+		WithArgs("1234-5678-123456", "Error", "Acknowledged").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mockSpy.ExpectCommit()
+
+	// ResetDevice: UPDATE device flags
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`^UPDATE "devices"`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mockSpy.ExpectCommit()
+
+	event := &types.CheckinEvent{
+		UDID:       "1234-5678-123456",
+		RawPayload: []byte(testDevicePlist),
+	}
+
+	err := handleCheckinEvent("mdm.CheckOut", event)
+
+	assert.NoError(t, err)
+}
+
+// mdm.CheckOut: if ClearCommands fails the error must propagate.
+func TestHandleCheckinEvent_CheckOut_PropagatesResetDeviceError(t *testing.T) {
+	utils.FlagProvider = mockFlagBuilder{false}
+
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{SkipDefaultTransaction: true})
+	db.DB = DB
+
+	mockSpy.ExpectExec(`.*`).
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnError(errDBGoneAway)
+
+	event := &types.CheckinEvent{
+		UDID:       "1234-5678-123456",
+		RawPayload: []byte(testDevicePlist),
+	}
+
+	err := handleCheckinEvent("mdm.CheckOut", event)
+
+	require.Error(t, err)
+}
+
+// ---- handleAcknowledgeEvent -----------------------------------------------------
+
+func TestHandleAcknowledgeEvent_InvalidPlist(t *testing.T) {
+	event := &types.AcknowledgeEvent{
+		RawPayload: []byte("not valid plist data"),
+	}
+
+	err := handleAcknowledgeEvent(event)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "handleAcknowledgeEvent:plist.Unmarshal")
+}
+
+// ---- processAcknowledgePayload --------------------------------------------------
+
+// ProfileList key in the payload dict must route to profile-verification logic.
+// An invalid plist in RawPayload surfaces the Unmarshal error path.
+func TestProcessAcknowledgePayload_ProfileList_InvalidPlist(t *testing.T) {
+	device := types.Device{UDID: "1234-5678-123456", SerialNumber: "C02ABCDEFGH"}
+	event := &types.AcknowledgeEvent{
+		RawPayload: []byte("not valid plist"),
+	}
+	payloadDict := map[string]interface{}{
+		"ProfileList": []interface{}{},
+	}
+
+	err := processAcknowledgePayload(event, device, payloadDict)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "processAcknowledgePayload:ProfileList:plist.Unmarshal")
+}
+
+// SecurityInfo key in the payload dict must route to security-info save logic.
+func TestProcessAcknowledgePayload_SecurityInfo_InvalidPlist(t *testing.T) {
+	device := types.Device{UDID: "1234-5678-123456", SerialNumber: "C02ABCDEFGH"}
+	event := &types.AcknowledgeEvent{
+		RawPayload: []byte("not valid plist"),
+	}
+	payloadDict := map[string]interface{}{
+		"SecurityInfo": map[string]interface{}{},
+	}
+
+	err := processAcknowledgePayload(event, device, payloadDict)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "processAcknowledgePayload:SecurityInfo:plist.Unmarshal")
+}
+
+// CertificateList key in the payload dict must route to certificate-list processing.
+func TestProcessAcknowledgePayload_CertificateList_InvalidPlist(t *testing.T) {
+	device := types.Device{UDID: "1234-5678-123456", SerialNumber: "C02ABCDEFGH"}
+	event := &types.AcknowledgeEvent{
+		RawPayload: []byte("not valid plist"),
+	}
+	payloadDict := map[string]interface{}{
+		"CertificateList": []interface{}{},
+	}
+
+	err := processAcknowledgePayload(event, device, payloadDict)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "processAcknowledgePayload:CertificateList:plist.Unmarshal")
+}
+
+// QueryResponses key in the payload dict must route to device-info update logic.
+func TestProcessAcknowledgePayload_QueryResponses_InvalidPlist(t *testing.T) {
+	device := types.Device{UDID: "1234-5678-123456", SerialNumber: "C02ABCDEFGH"}
+	event := &types.AcknowledgeEvent{
+		RawPayload: []byte("not valid plist"),
+	}
+	payloadDict := map[string]interface{}{
+		"QueryResponses": map[string]interface{}{},
+	}
+
+	err := processAcknowledgePayload(event, device, payloadDict)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "processAcknowledgePayload:QueryResponses:plist.Unmarshal")
+}

--- a/main.go
+++ b/main.go
@@ -330,7 +330,7 @@ func main() {
 		"use-ddm-packages",
 		env.Bool("USE_DDM_PACKAGES", false),
 		"Enable DDM package management via KMFDDM instead of InstallApplication commands",
-  )
+	)
 	flag.StringVar(
 		&DDMDeclarationPrefix,
 		"ddm-declaration-prefix",

--- a/main.go
+++ b/main.go
@@ -451,7 +451,7 @@ func main() {
 		log.Infof("Using local enrollment profile at %s", EnrollmentProfile)
 	}
 
-  if UseDDM || UseDDMPackages {
+	if UseDDM || UseDDMPackages {
 		if MDMServerType != string(mdm.ServerTypeNanoMDM) {
 			log.Fatal("DDM requires mdm-server-type=nanomdm. Exiting.")
 		}

--- a/main.go
+++ b/main.go
@@ -105,6 +105,9 @@ var KMFDDMAPIKey string
 // NanoMDMURL is the externally reachable URL of the NanoMDM server
 var NanoMDMURL string
 
+// NanoMDMAPIKey is the API key for the NanoMDM server
+var NanoMDMAPIKey string
+
 // UseDDM controls whether profile management uses DDM instead of InstallProfile
 var UseDDM bool
 
@@ -308,7 +311,13 @@ func main() {
 		&NanoMDMURL,
 		"nanomdm-url",
 		env.String("NANOMDM_URL", ""),
-		"NanoMDM server URL",
+		"NanoMDM server URL (required if mdm-server-type=nanomdm)",
+	)
+	flag.StringVar(
+		&NanoMDMAPIKey,
+		"nanomdm-api-key",
+		env.String("NANOMDM_API_KEY", ""),
+		"NanoMDM server API key (required if mdm-server-type=nanomdm)",
 	)
 	flag.BoolVar(
 		&UseDDM,
@@ -353,14 +362,6 @@ func main() {
 		})
 	}
 
-	if MicroMDMURL == "" {
-		log.Fatal("MicroMDM Server URL missing. Exiting.")
-	}
-
-	if MicroMDMAPIKey == "" {
-		log.Fatal("MicroMDM API Key missing. Exiting.")
-	}
-
 	if BasicAuthPass == "" {
 		log.Fatal("Basic Auth password missing. Exiting.")
 	}
@@ -374,15 +375,34 @@ func main() {
 		log.Fatal("loglevel value is not one of debug, info, warn or error.")
 	}
 
-	if UseDDM {
+	switch MDMServerType {
+	case string(mdm.ServerTypeMicroMDM):
+		if MicroMDMURL == "" {
+			log.Fatal("MicroMDM Server URL missing. Exiting.")
+		}
+		if MicroMDMAPIKey == "" {
+			log.Fatal("MicroMDM API Key missing. Exiting.")
+		}
+	case string(mdm.ServerTypeNanoMDM):
+		if NanoMDMURL == "" {
+			log.Fatal("NanoMDM Server URL missing. Exiting.")
+		}
+		if NanoMDMAPIKey == "" {
+			log.Fatal("NanoMDM API Key missing. Exiting.")
+		}
+	default:
+		log.Fatalf("Unknown MDM server type: %s. Must be 'micromdm' or 'nanomdm'. Exiting.", MDMServerType)
+	}
+
+	if UseDDM || UseDDMPackages {
+		if MDMServerType != string(mdm.ServerTypeNanoMDM) {
+			log.Fatal("DDM requires mdm-server-type=nanomdm. Exiting.")
+		}
 		if KMFDDMURL == "" {
 			log.Fatal("KMFDDM URL is required when DDM is enabled. Exiting.")
 		}
 		if KMFDDMAPIKey == "" {
 			log.Fatal("KMFDDM API Key is required when DDM is enabled. Exiting.")
-		}
-		if NanoMDMURL == "" {
-			log.Fatal("NanoMDM URL is required when DDM is enabled. Exiting.")
 		}
 		if DDMDeclarationPrefix == "" {
 			log.Fatal("DDM declaration prefix is required when DDM is enabled. Exiting.")
@@ -398,7 +418,7 @@ func main() {
 
 	// Initialize NanoMDM client only if configured to use NanoMDM
 	if MDMServerType == string(mdm.ServerTypeNanoMDM) {
-		mdm.InitClient(MicroMDMURL, MicroMDMAPIKey)
+		mdm.InitClient(NanoMDMURL, NanoMDMAPIKey)
 		director.InfoLogger(director.LogHolder{Message: "NanoMDM client initialized"})
 	} else {
 		director.InfoLogger(director.LogHolder{Message: "Using MicroMDM (default)"})

--- a/main.go
+++ b/main.go
@@ -107,6 +107,9 @@ var NanoMDMURL string
 // UseDDM controls whether profile management uses DDM instead of InstallProfile
 var UseDDM bool
 
+// UseDDMPackages controls whether package installation uses DDM instead of InstallApplication commands
+var UseDDMPackages bool
+
 func main() {
 	var port string
 	var debugMode bool
@@ -305,6 +308,12 @@ func main() {
 		"use-ddm",
 		env.Bool("USE_DDM", false),
 		"Enable DDM profile management via KMFDDM instead of InstallProfile commands",
+	)
+	flag.BoolVar(
+		&UseDDMPackages,
+		"use-ddm-packages",
+		env.Bool("USE_DDM_PACKAGES", false),
+		"Enable DDM package management via KMFDDM instead of InstallApplication commands",
 	)
 	flag.Parse()
 

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -144,6 +144,10 @@ func UseDDM() bool {
 	return flag.Lookup("use-ddm").Value.(flag.Getter).Get().(bool)
 }
 
+func UseDDMPackages() bool {
+	return flag.Lookup("use-ddm-packages").Value.(flag.Getter).Get().(bool)
+}
+
 // Code for testing goes down here
 // flags *can* be overwritten by using os.Args, but they cannot be parsed more than once or it results in a crash.
 // So, instead we inject an interface layer between the calling code that is swapped out during unit tests.

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -140,6 +140,10 @@ func NanoMDMURL() string {
 	return strings.TrimRight(flag.Lookup("nanomdm-url").Value.(flag.Getter).Get().(string), "/")
 }
 
+func NanoMDMAPIKey() string {
+	return flag.Lookup("nanomdm-api-key").Value.(flag.Getter).Get().(string)
+}
+
 func UseDDM() bool {
 	return flag.Lookup("use-ddm").Value.(flag.Getter).Get().(bool)
 }


### PR DESCRIPTION
Migrate InstallApplication to DDM (Declarative Device Management)
                                                                                                                      
  Extends the earlier InstallProfile→DDM migration to also cover package installation (InstallApplication), completing
   the transition of both profile and app management to DDM via KMFDDM.
   
 What changed:
 
 DDM push logic
  - director/ddm_app_push.go — Push packages via DDM (com.apple.configuration.management.package + ActivationSimple declarations); handles device-specific, shared, and bootstrap packages
  
  Feature flags (main.go, utils/flags.go)
  --use-ddm-packages / USE_DDM_PACKAGES — route package installation through DDM
  
  Routing updates (director/install_application.go)
  - PushInstallApplication, PushSharedInstallApplication, InstallBootstrapPackages dispatch to DDM path when
  UseDDMPackages() is true
  
  WebhookHandler refactor (director/webhook.go)
  - Split monolithic WebhookHandler into handleCheckinEvent, handleAcknowledgeEvent, and processAcknowledgePayload for clarity and testability
  - Moved SendDeviceConfigured/RunInitialTasks orchestration from UpdateDevice into the webhook handler (correct separation of concerns)

  Bug fix (director/device.go)
  - Fixed guard condition checking device.SerialNumber instead of newDevice.SerialNumber in UpdateDevice