### PR TITLE
[MDMv2] Re-Enrollment using MDMEnroll dynamic profile

### DIFF
--- a/director/certificate.go
+++ b/director/certificate.go
@@ -72,7 +72,7 @@ func parseCertificate(certListItem types.CertificateList) (*x509.Certificate, er
 
 // validateEnrollmentCertExpiry triggers re-enrollment if any SCEP or ACME enrollment cert is nearing expiry
 func validateEnrollmentCertExpiry(certList []types.CertificateList, device types.Device) error {
-	if !utils.UseMDMEnrollForReEnrollment() {
+	if !utils.EnableReEnrollViaWebhook() {
 		enrollmentProfile := utils.EnrollmentProfile()
 		if enrollmentProfile == "" {
 			InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "No enrollment profile set, not continuing with enrollment cert expiry check"})

--- a/director/enrollment_profile.go
+++ b/director/enrollment_profile.go
@@ -17,16 +17,16 @@ func reinstallEnrollmentProfile(device types.Device) error {
 	var profileBytes []byte
 	var err error
 
-	if utils.UseMDMEnrollForReEnrollment() {
+	if utils.EnableReEnrollViaWebhook() {
 		InfoLogger(LogHolder{
 			DeviceSerial: device.SerialNumber,
 			DeviceUDID:   device.UDID,
-			Message:      "Fetching enrollment profile from MDMEnroll",
+			Message:      "Fetching enrollment profile from webhook",
 		})
 
-		profileBytes, err = fetchEnrollmentProfileFromMDMEnroll(device)
+		profileBytes, err = fetchEnrollmentProfileFromWebhook(device)
 		if err != nil {
-			return errors.Wrap(err, "Failed to fetch enrollment profile from MDMEnroll")
+			return errors.Wrap(err, "Failed to fetch enrollment profile from webhook")
 		}
 	} else {
 		enrollmentProfile := utils.EnrollmentProfile()

--- a/director/enrollment_profile_test.go
+++ b/director/enrollment_profile_test.go
@@ -1,0 +1,273 @@
+package director
+
+import (
+	"encoding/json"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/mdmdirector/mdmdirector/db"
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/micromdm/go4/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// registerEnrollmentProfileFlags registers all flags consumed by reinstallEnrollmentProfile
+func registerEnrollmentProfileFlags(t *testing.T) {
+	t.Helper()
+	if flag.Lookup("enrollment-profile") == nil {
+		flag.String("enrollment-profile", env.String("ENROLLMENT_PROFILE", ""), "Path to enrollment profile.")
+	}
+	if flag.Lookup("enrollment-profile-signed") == nil {
+		flag.Bool("enrollment-profile-signed", env.Bool("ENROLMENT_PROFILE_SIGNED", false), "Is the enrollment profile pre-signed?")
+	}
+	if flag.Lookup("enable-reenroll-via-webhook") == nil {
+		flag.Bool("enable-reenroll-via-webhook", env.Bool("ENABLE_REENROLL_VIA_WEBHOOK", false), "Enable webhook-based re-enrollment.")
+	}
+	if flag.Lookup("micromdmurl") == nil {
+		flag.String("micromdmurl", env.String("MICROMDM_URL", "http://localhost:9000"), "MicroMDM server URL.")
+	}
+	if flag.Lookup("micromdmapikey") == nil {
+		flag.String("micromdmapikey", env.String("MICROMDM_API_KEY", ""), "MicroMDM API key.")
+	}
+	if flag.Lookup("sign") == nil {
+		flag.Bool("sign", env.Bool("SIGN", false), "Sign profiles prior to sending to MicroMDM.")
+	}
+	if flag.Lookup("prometheus") == nil {
+		flag.Bool("prometheus", env.Bool("PROMETHEUS", false), "Enable Prometheus metrics.")
+	}
+	if flag.Lookup("enroll-webhook-url") == nil {
+		flag.String("enroll-webhook-url", env.String("ENROLL_WEBHOOK_URL", ""), "Enrollment profile webhook URL.")
+	}
+	if flag.Lookup("enroll-webhook-token") == nil {
+		flag.String("enroll-webhook-token", env.String("ENROLL_WEBHOOK_TOKEN", ""), "Enrollment profile webhook bearer token.")
+	}
+}
+
+// setFlag sets an already-registered flag to value
+func setFlag(t *testing.T, name, value string) {
+	t.Helper()
+	require.NoError(t, flag.Set(name, value), "failed to set flag %q", name)
+}
+
+// writeTempProfile writes content to a temporary file and returns its path
+func writeTempProfile(t *testing.T, content []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "enrollment.mobileconfig")
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+	return path
+}
+
+// TestReinstallEnrollmentProfile_FileNotFound - missing enrollment profile
+func TestReinstallEnrollmentProfile_FileNotFound(t *testing.T) {
+	registerEnrollmentProfileFlags(t)
+	setFlag(t, "enable-reenroll-via-webhook", "false")
+	setFlag(t, "enrollment-profile-signed", "false")
+	setFlag(t, "enrollment-profile", "/nonexistent/path/to/enrollment.mobileconfig")
+
+	device := types.Device{UDID: "TEST-UDID-FILE-NOT-FOUND", SerialNumber: "C02NOTFOUND"}
+	err := reinstallEnrollmentProfile(device)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to read enrollment profile")
+}
+
+// TestReinstallEnrollmentProfile_InvalidPlist - invalid Plist
+func TestReinstallEnrollmentProfile_InvalidPlist(t *testing.T) {
+	registerEnrollmentProfileFlags(t)
+	setFlag(t, "enable-reenroll-via-webhook", "false")
+	setFlag(t, "enrollment-profile-signed", "false")
+
+	profilePath := writeTempProfile(t, []byte("this is not a valid plist %%%"))
+	setFlag(t, "enrollment-profile", profilePath)
+
+	device := types.Device{UDID: "TEST-UDID-BAD-PLIST", SerialNumber: "C02BADPLIST"}
+	err := reinstallEnrollmentProfile(device)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to unmarshal enrollment profile to struct")
+}
+
+// TestReinstallEnrollmentProfile_WebhookError - webhook server error
+func TestReinstallEnrollmentProfile_WebhookError(t *testing.T) {
+	registerEnrollmentProfileFlags(t)
+	setFlag(t, "enable-reenroll-via-webhook", "true")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	setFlag(t, "enroll-webhook-url", server.URL)
+	setFlag(t, "enroll-webhook-token", "test-token")
+
+	device := types.Device{UDID: "TEST-UDID-WEBHOOK-ERR", SerialNumber: "C02WEBHOOKERR"}
+	err := reinstallEnrollmentProfile(device)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to fetch enrollment profile from webhook")
+}
+
+// TestReinstallEnrollmentProfile_WebhookEmptyBody - empty profile from webhook
+func TestReinstallEnrollmentProfile_WebhookEmptyBody(t *testing.T) {
+	registerEnrollmentProfileFlags(t)
+	setFlag(t, "enable-reenroll-via-webhook", "true")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// intentionally write no body
+	}))
+	defer server.Close()
+
+	setFlag(t, "enroll-webhook-url", server.URL)
+	setFlag(t, "enroll-webhook-token", "test-token")
+
+	device := types.Device{UDID: "TEST-UDID-WEBHOOK-EMPTY", SerialNumber: "C02WEBHOOKEMPTY"}
+	err := reinstallEnrollmentProfile(device)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to fetch enrollment profile from webhook")
+}
+
+func setupMockDB(t *testing.T) (sqlmock.Sqlmock, func()) {
+	t.Helper()
+	oldDB := db.DB
+
+	postgresMock, mockSpy, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	require.NoError(t, err)
+
+	db.DB = gormDB
+
+	cleanup := func() {
+		db.DB = oldDB
+		postgresMock.Close()
+	}
+
+	return mockSpy, cleanup
+}
+
+// mockGetDevice sets up DB expectations for GetDevice
+func mockGetDevice(mockSpy sqlmock.Sqlmock, udid string) {
+	deviceRows1 := sqlmock.NewRows([]string{"ud_id", "serial_number"}).
+		AddRow(udid, "C02TEST123")
+	deviceRows2 := sqlmock.NewRows([]string{"ud_id", "serial_number"}).
+		AddRow(udid, "C02TEST123")
+
+	// First query from First()
+	mockSpy.ExpectQuery(`SELECT \* FROM "devices" WHERE ud_id = \$1 ORDER BY "devices"\."ud_id" LIMIT 1`).
+		WithArgs(udid).
+		WillReturnRows(deviceRows1)
+
+	// Second query from Scan() - includes primary key in WHERE clause
+	mockSpy.ExpectQuery(`SELECT \* FROM "devices" WHERE ud_id = \$1 AND "devices"\."ud_id" = \$2 ORDER BY "devices"\."ud_id" LIMIT 1`).
+		WithArgs(udid, udid).
+		WillReturnRows(deviceRows2)
+}
+
+// fakeMicroMDMServer returns an httptest.Server that mimics the MicroMDM - /v1/commands
+func fakeMicroMDMServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := types.CommandResponse{}
+		resp.Payload.CommandUUID = "test-cmd-uuid-0001"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// minimalUnsignedProfile - valid mobileconfig plist that can be unmarshalled into types.DeviceProfile
+const minimalUnsignedProfile = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array/>
+	<key>PayloadDisplayName</key>
+	<string>Test Enrollment</string>
+	<key>PayloadIdentifier</key>
+	<string>com.example.test.enrollment</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>AABBCCDD-0001-0002-0003-000000000001</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>`
+
+// TestReinstallEnrollmentProfile_Webhook_Success verifies the success path where
+// the webhook returns a valid profile and PushProfiles sends it successfully
+func TestReinstallEnrollmentProfile_Webhook_Success(t *testing.T) {
+	registerEnrollmentProfileFlags(t)
+	setFlag(t, "enable-reenroll-via-webhook", "true")
+	setFlag(t, "enrollment-profile-signed", "false")
+	setFlag(t, "sign", "false")
+
+	// Webhook server returns a valid unsigned plist.
+	webhookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(minimalUnsignedProfile))
+	}))
+	defer webhookServer.Close()
+	setFlag(t, "enroll-webhook-url", webhookServer.URL)
+	setFlag(t, "enroll-webhook-token", "test-token")
+
+	// Fake MicroMDM server that PushProfiles/SendCommand will POST to.
+	mdmServer := fakeMicroMDMServer(t)
+	defer mdmServer.Close()
+	setFlag(t, "micromdmurl", mdmServer.URL)
+
+	device := types.Device{UDID: "TEST-UDID-WEBHOOK-OK", SerialNumber: "C02WEBHOOKOK"}
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+	mockGetDevice(mockSpy, device.UDID)
+
+	err := reinstallEnrollmentProfile(device)
+	require.NoError(t, err)
+}
+
+// TestGetEnrollmentProfile_Found - returns enrollment profile from list of profiles
+func TestGetEnrollmentProfile_Found(t *testing.T) {
+	profileLists := []types.ProfileList{
+		{
+			PayloadUUID:       "UUID-0001",
+			PayloadIdentifier: "com.example.other",
+			PayloadContent: []types.PayloadContentItem{
+				{PayloadType: "com.example.other"},
+			},
+		},
+		{
+			PayloadUUID:       "UUID-0002",
+			PayloadIdentifier: "com.example.mdm",
+			PayloadContent: []types.PayloadContentItem{
+				{PayloadType: "com.apple.mdm"},
+			},
+		},
+	}
+
+	profile, found := getEnrollmentProfile(profileLists)
+	require.True(t, found, "expected enrollment profile to be found")
+	assert.Equal(t, "UUID-0002", profile.PayloadUUID)
+}
+
+// TestGetEnrollmentProfile_NotFound - no enrollment profile found
+func TestGetEnrollmentProfile_NotFound(t *testing.T) {
+	profileLists := []types.ProfileList{
+		{
+			PayloadUUID: "UUID-0001",
+			PayloadContent: []types.PayloadContentItem{
+				{PayloadType: "com.example.wifi"},
+			},
+		},
+	}
+
+	_, found := getEnrollmentProfile(profileLists)
+	assert.False(t, found, "expected no enrollment profile to be found")
+}

--- a/director/enrollmentwebhook_client.go
+++ b/director/enrollmentwebhook_client.go
@@ -47,16 +47,16 @@ func buildMachineInfoHeader(device types.Device) (string, error) {
 	return base64.StdEncoding.EncodeToString(plistBytes), nil
 }
 
-// fetchEnrollmentProfileFromMDMEnroll gets enrollment profile from MDMEnroll's re-enroll endpoint
-func fetchEnrollmentProfileFromMDMEnroll(device types.Device) ([]byte, error) {
-	url := utils.MDMEnrollURL() + utils.MDMEnrollReEnrollPath()
+// fetchEnrollmentProfileFromWebhook gets enrollment profile from the enrollment profile webhook endpoint
+func fetchEnrollmentProfileFromWebhook(device types.Device) ([]byte, error) {
+	url := utils.EnrollWebhookURL()
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "create MDMEnroll request")
+		return nil, errors.Wrap(err, "create enrollment profile webhook request")
 	}
 
-	req.Header.Set("Authorization", "Bearer "+utils.MDMEnrollAPIToken())
+	req.Header.Set("Authorization", "Bearer "+utils.EnrollWebhookToken())
 
 	headerValue, err := buildMachineInfoHeader(device)
 	if err != nil {
@@ -67,27 +67,27 @@ func fetchEnrollmentProfileFromMDMEnroll(device types.Device) ([]byte, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "MDMEnroll request failed")
+		return nil, errors.Wrap(err, "enrollment profile webhook request failed")
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "read MDMEnroll response body")
+		return nil, errors.Wrap(err, "read enrollment profile webhook response body")
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("MDMEnroll returned status %d: %s", resp.StatusCode, string(body))
+		return nil, errors.Errorf("enrollment profile webhook returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	if len(body) == 0 {
-		return nil, errors.New("MDMEnroll returned empty enrollment profile")
+		return nil, errors.New("enrollment profile webhook returned empty enrollment profile")
 	}
 
 	InfoLogger(LogHolder{
 		DeviceUDID:   device.UDID,
 		DeviceSerial: device.SerialNumber,
-		Message:      "Successfully fetched enrollment profile from MDMEnroll",
+		Message:      "Successfully fetched enrollment profile from webhook",
 	})
 	return body, nil
 }

--- a/director/enrollmentwebhook_client_test.go
+++ b/director/enrollmentwebhook_client_test.go
@@ -1,0 +1,136 @@
+package director
+
+import (
+	"encoding/base64"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/micromdm/go4/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// registerEnrollWebhookFlags registers the flags used by the enrollment profile webhook client
+func registerEnrollWebhookFlags() {
+	if flag.Lookup("enroll-webhook-url") == nil {
+		var enrollWebhookURL string
+		flag.StringVar(&enrollWebhookURL, "enroll-webhook-url", env.String("ENROLL_WEBHOOK_URL", ""), "Full URL of the enrollment profile webhook endpoint.")
+	}
+	if flag.Lookup("enroll-webhook-token") == nil {
+		var enrollWebhookToken string
+		flag.StringVar(&enrollWebhookToken, "enroll-webhook-token", env.String("ENROLL_WEBHOOK_TOKEN", ""), "Bearer token for the enrollment profile webhook.")
+	}
+}
+
+// setFlagValue sets the value of a registered flag by name
+func setFlagValue(t *testing.T, name, value string) {
+	t.Helper()
+	err := flag.Set(name, value)
+	require.NoError(t, err, "failed to set flag %q", name)
+}
+
+func TestFetchEnrollmentProfileFromWebhook_Success(t *testing.T) {
+	registerEnrollWebhookFlags()
+
+	expectedProfile := []byte("<?xml version=\"1.0\"?><plist><dict></dict></plist>")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify Authorization header
+		assert.Equal(t, "Bearer test-token-123", r.Header.Get("Authorization"))
+
+		// Verify device info header is present and valid base64
+		deviceInfoHeader := r.Header.Get("X-Apple-Aspen-Deviceinfo")
+		assert.NotEmpty(t, deviceInfoHeader)
+		_, err := base64.StdEncoding.DecodeString(deviceInfoHeader)
+		assert.NoError(t, err, "X-Apple-Aspen-Deviceinfo must be valid base64")
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(expectedProfile)
+	}))
+	defer server.Close()
+
+	setFlagValue(t, "enroll-webhook-url", server.URL)
+	setFlagValue(t, "enroll-webhook-token", "test-token-123")
+
+	device := types.Device{
+		UDID:         "TEST-UDID-0001",
+		SerialNumber: "C02TEST0001",
+		Model:        "MacBookPro18,3",
+	}
+
+	profile, err := fetchEnrollmentProfileFromWebhook(device)
+	require.NoError(t, err)
+	assert.Equal(t, expectedProfile, profile)
+}
+
+func TestFetchEnrollmentProfileFromWebhook_Non200Status(t *testing.T) {
+	registerEnrollWebhookFlags()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	setFlagValue(t, "enroll-webhook-url", server.URL)
+	setFlagValue(t, "enroll-webhook-token", "bad-token")
+
+	device := types.Device{UDID: "TEST-UDID-0002", SerialNumber: "C02TEST0002", Model: "iPad13,4"}
+
+	_, err := fetchEnrollmentProfileFromWebhook(device)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestFetchEnrollmentProfileFromWebhook_EmptyBody(t *testing.T) {
+	registerEnrollWebhookFlags()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Write nothing — empty body.
+	}))
+	defer server.Close()
+
+	setFlagValue(t, "enroll-webhook-url", server.URL)
+	setFlagValue(t, "enroll-webhook-token", "some-token")
+
+	device := types.Device{UDID: "TEST-UDID-0003", SerialNumber: "C02TEST0003", Model: "iPad13,4"}
+
+	_, err := fetchEnrollmentProfileFromWebhook(device)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty enrollment profile")
+}
+
+func TestFetchEnrollmentProfileFromWebhook_DeviceInfoHeaderEncoded(t *testing.T) {
+	registerEnrollWebhookFlags()
+
+	device := types.Device{
+		UDID:         "DEVICE-UDID-7",
+		SerialNumber: "SN007",
+		Model:        "iPad13,16",
+		OSVersion:    "17.0",
+		BuildVersion: "21A329",
+	}
+
+	// Pre-compute expected header so we can compare against what the server receives.
+	expectedHeader, err := buildMachineInfoHeader(device)
+	require.NoError(t, err)
+
+	var receivedHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeader = r.Header.Get("X-Apple-Aspen-Deviceinfo")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("profile"))
+	}))
+	defer server.Close()
+
+	setFlagValue(t, "enroll-webhook-url", server.URL)
+	setFlagValue(t, "enroll-webhook-token", "tok")
+
+	_, err = fetchEnrollmentProfileFromWebhook(device)
+	require.NoError(t, err)
+	assert.Equal(t, expectedHeader, receivedHeader)
+}

--- a/director/mdmenroll_client.go
+++ b/director/mdmenroll_client.go
@@ -1,0 +1,93 @@
+package director
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/groob/plist"
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/mdmdirector/mdmdirector/utils"
+	"github.com/pkg/errors"
+)
+
+// machineInfoPlist represents the MachineInfo plist
+type machineInfoPlist struct {
+	IMEI                       string `plist:"IMEI,omitempty"`
+	MEID                       string `plist:"MEID,omitempty"`
+	OSVersion                  string `plist:"OS_VERSION,omitempty"`
+	Product                    string `plist:"PRODUCT"`
+	Serial                     string `plist:"SERIAL"`
+	SupplementalBuildVersion   string `plist:"SUPPLEMENTAL_BUILD_VERSION,omitempty"`
+	SupplementalOSVersionExtra string `plist:"SUPPLEMENTAL_OS_VERSION_EXTRA,omitempty"`
+	UDID                       string `plist:"UDID"`
+	Version                    string `plist:"VERSION,omitempty"`
+}
+
+// buildMachineInfoHeader constructs machineInfo plist from device's attributes
+func buildMachineInfoHeader(device types.Device) (string, error) {
+	info := machineInfoPlist{
+		IMEI:                       device.IMEI,
+		MEID:                       device.MEID,
+		OSVersion:                  device.OSVersion,
+		Product:                    device.Model,
+		Serial:                     device.SerialNumber,
+		SupplementalBuildVersion:   device.SupplementalBuildVersion,
+		SupplementalOSVersionExtra: device.SupplementalOSVersionExtra,
+		UDID:                       device.UDID,
+		Version:                    device.BuildVersion,
+	}
+
+	plistBytes, err := plist.Marshal(info)
+	if err != nil {
+		return "", errors.Wrap(err, "marshal MachineInfo plist")
+	}
+
+	return base64.StdEncoding.EncodeToString(plistBytes), nil
+}
+
+// fetchEnrollmentProfileFromMDMEnroll gets enrollment profile from MDMEnroll's re-enroll endpoint
+func fetchEnrollmentProfileFromMDMEnroll(device types.Device) ([]byte, error) {
+	url := utils.MDMEnrollURL() + utils.MDMEnrollReEnrollPath()
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "create MDMEnroll request")
+	}
+
+	req.Header.Set("Authorization", "Bearer "+utils.MDMEnrollAPIToken())
+
+	headerValue, err := buildMachineInfoHeader(device)
+	if err != nil {
+		return nil, errors.Wrap(err, "build MachineInfo header")
+	}
+	req.Header.Set("X-Apple-Aspen-Deviceinfo", headerValue)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "MDMEnroll request failed")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read MDMEnroll response body")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("MDMEnroll returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	if len(body) == 0 {
+		return nil, errors.New("MDMEnroll returned empty enrollment profile")
+	}
+
+	InfoLogger(LogHolder{
+		DeviceUDID:   device.UDID,
+		DeviceSerial: device.SerialNumber,
+		Message:      "Successfully fetched enrollment profile from MDMEnroll",
+	})
+	return body, nil
+}

--- a/director/profile_test.go
+++ b/director/profile_test.go
@@ -104,14 +104,9 @@ func TestValidateProfileInProfileList(t *testing.T) {
 	defer log.SetLevel(log.InfoLevel)
 
 	// set up global sign flag
-	var Sign bool
-	flag.BoolVar(
-		&Sign,
-		"sign",
-		env.Bool("SIGN", false),
-		"Sign profiles prior to sending to MicroMDM.",
-	)
-
+	if flag.Lookup("sign") == nil {
+		flag.Bool("sign", env.Bool("SIGN", false), "Sign profiles prior to sending to MicroMDM.")
+	}
 	// decode test signer cert
 	p, _ := pem.Decode([]byte(testSignerCert))
 	signer, err := x509.ParseCertificate(p.Bytes)
@@ -243,9 +238,13 @@ func TestValidateProfileInProfileList(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			Sign = test.signCheck
+			signVal := "false"
+			if test.signCheck {
+				signVal = "true"
+			}
+			require.NoError(t, flag.Set("sign", signVal))
 			var s *x509.Certificate
-			if Sign {
+			if test.signCheck {
 				s = signer
 			}
 			install, needsReinstall, err := validateProfileInProfileList(test.profile, test.profileList, s)

--- a/main.go
+++ b/main.go
@@ -109,6 +109,9 @@ var MDMEnrollReEnrollPath string
 // MDMEnrollAPIToken is the Bearer token for the MDMEnroll re-enrollment endpoint
 var MDMEnrollAPIToken string
 
+// EnableReEnrollViaMdmEnroll enables re-enrollment via the MDMEnroll service
+var EnableReEnrollViaMdmEnroll bool
+
 func main() {
 	var port string
 	var debugMode bool
@@ -314,6 +317,12 @@ func main() {
 		env.String("MDMENROLL_API_TOKEN", ""),
 		"Bearer token for the MDMEnroll re-enrollment endpoint.",
 	)
+	flag.BoolVar(
+		&EnableReEnrollViaMdmEnroll,
+		"enable-reenroll-via-mdmenroll",
+		env.Bool("ENABLE_REENROLL_VIA_MDMENROLL", false),
+		"Enable re-enrollment via the MDMEnroll service.",
+	)
 	flag.Parse()
 
 	logLevel, err := log.ParseLevel(LogLevel)
@@ -354,9 +363,12 @@ func main() {
 		log.Fatal("loglevel value is not one of debug, info, warn or error.")
 	}
 
-	if MDMEnrollURL != "" {
+	if EnableReEnrollViaMdmEnroll {
+		if MDMEnrollURL == "" {
+			log.Fatal("MDMENROLL_URL is required when --enable-reenroll-via-mdmenroll is set. Exiting.")
+		}
 		if MDMEnrollAPIToken == "" {
-			log.Fatal("MDMENROLL_API_TOKEN is required when MDMENROLL_URL is set. Exiting.")
+			log.Fatal("MDMENROLL_API_TOKEN is required when --enable-reenroll-via-mdmenroll is set. Exiting.")
 		}
 		log.Infof("Using MDMEnroll re-enrollment endpoint at %s%s", MDMEnrollURL, MDMEnrollReEnrollPath)
 		if !Sign {

--- a/main.go
+++ b/main.go
@@ -100,17 +100,14 @@ var AcmeCertIssuer string
 // AcmeCertMinValidity is the minimum number of days before ACME cert expiry to trigger re-enrollment
 var AcmeCertMinValidity int
 
-// MDMEnrollURL is the base URL of the MDMEnroll service
-var MDMEnrollURL string
+// EnrollWebhookURL is the full URL of the enrollment profile webhook endpoint
+var EnrollWebhookURL string
 
-// MDMEnrollReEnrollPath is the path to the re-enrollment endpoint
-var MDMEnrollReEnrollPath string
+// EnrollWebhookToken is the Bearer token for the enrollment profile webhook
+var EnrollWebhookToken string
 
-// MDMEnrollAPIToken is the Bearer token for the MDMEnroll re-enrollment endpoint
-var MDMEnrollAPIToken string
-
-// EnableReEnrollViaMdmEnroll enables re-enrollment via the MDMEnroll service
-var EnableReEnrollViaMdmEnroll bool
+// EnableReEnrollViaWebhook enables fetching enrollment profiles via a remote webhook for re-enrollment
+var EnableReEnrollViaWebhook bool
 
 func main() {
 	var port string
@@ -300,28 +297,22 @@ func main() {
 		"Number of minutes to wait between issuing information commands",
 	)
 	flag.StringVar(
-		&MDMEnrollURL,
-		"mdmenroll-url",
-		env.String("MDMENROLL_URL", ""),
-		"Base URL of the MDMEnroll service for fetching enrollment profiles.",
+		&EnrollWebhookURL,
+		"enroll-webhook-url",
+		env.String("ENROLL_WEBHOOK_URL", ""),
+		"URL of the enrollment profile webhook endpoint",
 	)
 	flag.StringVar(
-		&MDMEnrollReEnrollPath,
-		"mdmenroll-reenroll-path",
-		env.String("MDMENROLL_REENROLL_PATH", "/mdm/reenroll"),
-		"Path to the MDMEnroll re-enrollment endpoint.",
-	)
-	flag.StringVar(
-		&MDMEnrollAPIToken,
-		"mdmenroll-api-token",
-		env.String("MDMENROLL_API_TOKEN", ""),
-		"Bearer token for the MDMEnroll re-enrollment endpoint.",
+		&EnrollWebhookToken,
+		"enroll-webhook-token",
+		env.String("ENROLL_WEBHOOK_TOKEN", ""),
+		"Bearer token for the enrollment profile webhook",
 	)
 	flag.BoolVar(
-		&EnableReEnrollViaMdmEnroll,
-		"enable-reenroll-via-mdmenroll",
-		env.Bool("ENABLE_REENROLL_VIA_MDMENROLL", false),
-		"Enable re-enrollment via the MDMEnroll service.",
+		&EnableReEnrollViaWebhook,
+		"enable-reenroll-via-webhook",
+		env.Bool("ENABLE_REENROLL_VIA_WEBHOOK", false),
+		"Enable fetching the enrollment profile from a remote webhook for re-enrollment",
 	)
 	flag.Parse()
 
@@ -363,16 +354,16 @@ func main() {
 		log.Fatal("loglevel value is not one of debug, info, warn or error.")
 	}
 
-	if EnableReEnrollViaMdmEnroll {
-		if MDMEnrollURL == "" {
-			log.Fatal("MDMENROLL_URL is required when --enable-reenroll-via-mdmenroll is set. Exiting.")
+	if EnableReEnrollViaWebhook {
+		if EnrollWebhookURL == "" {
+			log.Fatal("ENROLL_WEBHOOK_URL is required when --enable-reenroll-via-webhook is set")
 		}
-		if MDMEnrollAPIToken == "" {
-			log.Fatal("MDMENROLL_API_TOKEN is required when --enable-reenroll-via-mdmenroll is set. Exiting.")
+		if EnrollWebhookToken == "" {
+			log.Fatal("ENROLL_WEBHOOK_TOKEN is required when --enable-reenroll-via-webhook is set")
 		}
-		log.Infof("Using MDMEnroll re-enrollment endpoint at %s%s", MDMEnrollURL, MDMEnrollReEnrollPath)
+		log.Infof("Using enrollment profile webhook at %s", EnrollWebhookURL)
 		if !Sign {
-			log.Warn("Profile signing is disabled but required for MDMEnroll MachineInfo header construction.")
+			log.Warn("Profile signing is disabled but is required for MachineInfo header construction")
 		}
 	} else if EnrollmentProfile != "" {
 		log.Infof("Using local enrollment profile at %s", EnrollmentProfile)

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -148,8 +148,12 @@ func MDMEnrollAPIToken() string {
 	return flag.Lookup("mdmenroll-api-token").Value.(flag.Getter).Get().(string)
 }
 
+func EnableReEnrollViaMdmEnroll() bool {
+	return flag.Lookup("enable-reenroll-via-mdmenroll").Value.(flag.Getter).Get().(bool)
+}
+
 func UseMDMEnrollForReEnrollment() bool {
-	return MDMEnrollURL() != ""
+	return EnableReEnrollViaMdmEnroll()
 }
 
 func AcmeCertIssuer() string {

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -136,6 +136,30 @@ func InfoRequestInterval() int {
 	return flag.Lookup("info-request-interval").Value.(flag.Getter).Get().(int)
 }
 
+func MDMEnrollURL() string {
+	return strings.TrimRight(flag.Lookup("mdmenroll-url").Value.(flag.Getter).Get().(string), "/")
+}
+
+func MDMEnrollReEnrollPath() string {
+	return flag.Lookup("mdmenroll-reenroll-path").Value.(flag.Getter).Get().(string)
+}
+
+func MDMEnrollAPIToken() string {
+	return flag.Lookup("mdmenroll-api-token").Value.(flag.Getter).Get().(string)
+}
+
+func UseMDMEnrollForReEnrollment() bool {
+	return MDMEnrollURL() != ""
+}
+
+func AcmeCertIssuer() string {
+	return flag.Lookup("acme-cert-issuer").Value.(flag.Getter).Get().(string)
+}
+
+func AcmeCertMinValidity() int {
+	return flag.Lookup("acme-cert-min-validity").Value.(flag.Getter).Get().(int)
+}
+
 // Code for testing goes down here
 // flags *can* be overwritten by using os.Args, but they cannot be parsed more than once or it results in a crash.
 // So, instead we inject an interface layer between the calling code that is swapped out during unit tests.

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -136,24 +136,16 @@ func InfoRequestInterval() int {
 	return flag.Lookup("info-request-interval").Value.(flag.Getter).Get().(int)
 }
 
-func MDMEnrollURL() string {
-	return strings.TrimRight(flag.Lookup("mdmenroll-url").Value.(flag.Getter).Get().(string), "/")
+func EnrollWebhookURL() string {
+	return strings.TrimRight(flag.Lookup("enroll-webhook-url").Value.(flag.Getter).Get().(string), "/")
 }
 
-func MDMEnrollReEnrollPath() string {
-	return flag.Lookup("mdmenroll-reenroll-path").Value.(flag.Getter).Get().(string)
+func EnrollWebhookToken() string {
+	return flag.Lookup("enroll-webhook-token").Value.(flag.Getter).Get().(string)
 }
 
-func MDMEnrollAPIToken() string {
-	return flag.Lookup("mdmenroll-api-token").Value.(flag.Getter).Get().(string)
-}
-
-func EnableReEnrollViaMdmEnroll() bool {
-	return flag.Lookup("enable-reenroll-via-mdmenroll").Value.(flag.Getter).Get().(bool)
-}
-
-func UseMDMEnrollForReEnrollment() bool {
-	return EnableReEnrollViaMdmEnroll()
+func EnableReEnrollViaWebhook() bool {
+	return flag.Lookup("enable-reenroll-via-webhook").Value.(flag.Getter).Get().(bool)
 }
 
 func AcmeCertIssuer() string {


### PR DESCRIPTION
Add ACME certificate renewal and webhook-based re-enrollment support

- ACME cert expiry checks:
Extends enrollment certificate expiry monitoring to cover both SCEP and ACME certificates. New flags --acme-cert-issuer and --acme-cert-min-validity (default 180 days) allow configuring the ACME issuer and expiry threshold alongside the existing SCEP settings
  
  - Webhook-based re-enrollment:
  Adds an mode (--enable-reenroll-via-webhook) to fetch the enrollment profile from a remote HTTP endpoint instead of a local file (ACME enrollment profiles have dynamic content, cannot be stored as static file as SCEP). The webhook request includes a Bearer token (--enroll-webhook-token) and a base64-encoded X-Apple-Aspen-Deviceinfo header constructed from device attributes, mirroring the standard Apple enrollment device-info handshake
  
  - Enrollment profile check refactor:
  Extracts getEnrollmentProfile helper and simplifies ensureCertOnEnrollmentProfile to reduce nesting and improve readability. The certificate expiry validation is consolidated into a single validateEnrollmentCertExpiry function that iterates over all certificates once.