### PR TITLE
feat: Add TLS support for redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ These flags enable Declarative Device Management via KMFDDM. DDM requires `mdm-s
 - `-redis-host string` - Hostname of your Redis instance. (default "localhost") Env: `REDIS_HOST`
 - `-redis-port string` - Port of your Redis instance. (default "6379") Env: `REDIS_PORT`
 - `-redis-password string` - Password for your Redis instance. (default "") Env: `REDIS_PASSWORD`
+- `-redis-tls` - Enable TLS for the Redis connection. Required when connecting to ElastiCache with transit encryption enabled. (default false) Env: `REDIS_TLS`
 
 #### Profile Signing
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ These flags enable Declarative Device Management via KMFDDM. DDM requires `mdm-s
 - `-redis-host string` - Hostname of your Redis instance. (default "localhost") Env: `REDIS_HOST`
 - `-redis-port string` - Port of your Redis instance. (default "6379") Env: `REDIS_PORT`
 - `-redis-password string` - Password for your Redis instance. (default "") Env: `REDIS_PASSWORD`
-- `-redis-tls` - Enable TLS for the Redis connection. Required when connecting to ElastiCache with transit encryption enabled. (default false) Env: `REDIS_TLS`
+- `-redis-tls` - Enable TLS for the Redis connection. (default false) Env: `REDIS_TLS`
 
 #### Profile Signing
 

--- a/director/redis.go
+++ b/director/redis.go
@@ -1,6 +1,7 @@
 package director
 
 import (
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -16,11 +17,17 @@ func RedisClient() *redis.Client {
 
 	connectionString := fmt.Sprintf("%v:%v", host, port)
 
-	rdb := redis.NewClient(&redis.Options{
+	opts := &redis.Options{
 		Addr:     connectionString,
 		Password: password,
-		DB:       0, // use default DB
-	})
+		DB:       0,
+	}
+
+	if utils.RedisTLS() {
+		opts.TLSConfig = &tls.Config{}
+	}
+
+	rdb := redis.NewClient(opts)
 	time.Sleep(5 * time.Second)
 	return rdb
 }

--- a/main.go
+++ b/main.go
@@ -92,6 +92,8 @@ var RedisPort string
 
 var RedisPassword string
 
+var RedisTLS bool
+
 var OnceIn int
 
 var InfoRequestInterval int
@@ -230,6 +232,12 @@ func main() {
 		"redis-password",
 		env.String("REDIS_PASSWORD", ""),
 		"Redis password",
+	)
+	flag.BoolVar(
+		&RedisTLS,
+		"redis-tls",
+		env.Bool("REDIS_TLS", false),
+		"Enable TLS for Redis connection",
 	)
 	flag.StringVar(
 		&DBSSLMode,

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -128,6 +128,10 @@ func RedisPassword() string {
 	return flag.Lookup("redis-password").Value.(flag.Getter).Get().(string)
 }
 
+func RedisTLS() bool {
+	return flag.Lookup("redis-tls").Value.(flag.Getter).Get().(bool)
+}
+
 func OnceIn() int {
 	return flag.Lookup("once-in").Value.(flag.Getter).Get().(int)
 }


### PR DESCRIPTION
Enables MDMDirector to use TLS when connecting to redis improving security