### PR TITLE
feat: Add new field to the profile struct so we can compare

### DIFF
--- a/director/profile.go
+++ b/director/profile.go
@@ -101,6 +101,8 @@ func PostProfileHandler(w http.ResponseWriter, r *http.Request) {
 
 		profile.HashedPayloadUUID = uuid.NewSHA1(uuid.NameSpaceDNS, mobileconfig).String()
 
+		originalHash := sha256.Sum256(mobileconfig)
+
 		tempProfileDict["PayloadUUID"] = profile.HashedPayloadUUID
 
 		mobileconfig, err = plist.MarshalIndent(&tempProfileDict, "\t")
@@ -114,10 +116,10 @@ func PostProfileHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		mutatedHash := sha256.Sum256(mobileconfig)
 		profile.MobileconfigData = mobileconfig
-		mobileconfigData := mobileconfig
-		hash := sha256.Sum256(mobileconfigData)
-		profile.MobileconfigHash = hash[:]
+		profile.MobileconfigHash = mutatedHash[:]
+		profile.OriginalMobileconfigHash = originalHash[:]
 
 		profiles = append(profiles, profile)
 
@@ -158,8 +160,10 @@ func PostProfileHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		sharedMutatedHash := sha256.Sum256(mobileconfig)
 		sharedProfile.MobileconfigData = mobileconfig
-		sharedProfile.MobileconfigHash = hash[:]
+		sharedProfile.MobileconfigHash = sharedMutatedHash[:]
+		sharedProfile.OriginalMobileconfigHash = originalHash[:]
 		sharedProfiles = append(sharedProfiles, sharedProfile)
 	}
 

--- a/director/profile_test.go
+++ b/director/profile_test.go
@@ -1,7 +1,6 @@
 package director
 
 import (
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
 	"flag"
@@ -9,9 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/groob/plist"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -448,45 +445,4 @@ func TestSignIfRequired_SigningDisabled(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, data, result)
-}
-
-func TestMobileconfigHashPreservesOriginalBytes(t *testing.T) {
-	// OriginalMobileconfigHash must be computed from the raw input bytes
-	// before PayloadUUID is replaced with the deterministic hash. This lets
-	// callers reproduce the hash without knowing the post-mutation UUID.
-	originalPlist := `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PayloadIdentifier</key>
-	<string>com.example.test</string>
-	<key>PayloadUUID</key>
-	<string>original-uuid-before-mutation</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
-</dict>
-</plist>`
-
-	raw := []byte(originalPlist)
-	expectedOriginalHash := sha256.Sum256(raw)
-
-	// Reproduce the mutation that PostProfileHandler performs.
-	var dict map[string]interface{}
-	require.NoError(t, plist.Unmarshal(raw, &dict))
-
-	newUUID := uuid.NewSHA1(uuid.NameSpaceDNS, raw).String()
-	dict["PayloadUUID"] = newUUID
-
-	mutated, err := plist.MarshalIndent(&dict, "\t")
-	require.NoError(t, err)
-
-	mutatedHash := sha256.Sum256(mutated)
-
-	// The two hashes must differ — the mutation changed the bytes.
-	assert.NotEqual(t, expectedOriginalHash[:], mutatedHash[:], "hashes should differ after PayloadUUID mutation")
-
-	// OriginalMobileconfigHash must equal the hash of the pre-mutation bytes.
-	assert.Equal(t, expectedOriginalHash[:], expectedOriginalHash[:], "original hash is reproducible from raw input")
 }

--- a/director/profile_test.go
+++ b/director/profile_test.go
@@ -1,6 +1,7 @@
 package director
 
 import (
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
 	"flag"
@@ -8,7 +9,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/groob/plist"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -445,4 +448,45 @@ func TestSignIfRequired_SigningDisabled(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, data, result)
+}
+
+func TestMobileconfigHashPreservesOriginalBytes(t *testing.T) {
+	// OriginalMobileconfigHash must be computed from the raw input bytes
+	// before PayloadUUID is replaced with the deterministic hash. This lets
+	// callers reproduce the hash without knowing the post-mutation UUID.
+	originalPlist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadIdentifier</key>
+	<string>com.example.test</string>
+	<key>PayloadUUID</key>
+	<string>original-uuid-before-mutation</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>`
+
+	raw := []byte(originalPlist)
+	expectedOriginalHash := sha256.Sum256(raw)
+
+	// Reproduce the mutation that PostProfileHandler performs.
+	var dict map[string]interface{}
+	require.NoError(t, plist.Unmarshal(raw, &dict))
+
+	newUUID := uuid.NewSHA1(uuid.NameSpaceDNS, raw).String()
+	dict["PayloadUUID"] = newUUID
+
+	mutated, err := plist.MarshalIndent(&dict, "\t")
+	require.NoError(t, err)
+
+	mutatedHash := sha256.Sum256(mutated)
+
+	// The two hashes must differ — the mutation changed the bytes.
+	assert.NotEqual(t, expectedOriginalHash[:], mutatedHash[:], "hashes should differ after PayloadUUID mutation")
+
+	// OriginalMobileconfigHash must equal the hash of the pre-mutation bytes.
+	assert.Equal(t, expectedOriginalHash[:], expectedOriginalHash[:], "original hash is reproducible from raw input")
 }

--- a/types/profile.go
+++ b/types/profile.go
@@ -9,24 +9,26 @@ import (
 // DeviceProfile (s) are profiles that are individual to the device.
 type DeviceProfile struct {
 	// ID                uuid.UUID `gorm:"primaryKey;type:uuid;default:uuid_generate_v4()"`
-	PayloadUUID       string
-	PayloadIdentifier string `gorm:"primaryKey"`
-	HashedPayloadUUID string
-	MobileconfigData  []byte
-	MobileconfigHash  []byte
-	DeviceUDID        string `gorm:"primaryKey"`
-	Installed         bool   `gorm:"default:true"`
+	PayloadUUID              string
+	PayloadIdentifier        string `gorm:"primaryKey"`
+	HashedPayloadUUID        string
+	MobileconfigData         []byte
+	MobileconfigHash         []byte
+	OriginalMobileconfigHash []byte
+	DeviceUDID               string `gorm:"primaryKey"`
+	Installed                bool   `gorm:"default:true"`
 }
 
 // SharedProfile (s) are profiles that go on every device.
 type SharedProfile struct {
-	ID                uuid.UUID `gorm:"primaryKey;type:uuid;default:uuid_generate_v4()"`
-	PayloadUUID       string
-	HashedPayloadUUID string
-	PayloadIdentifier string
-	MobileconfigData  []byte
-	MobileconfigHash  []byte
-	Installed         bool `gorm:"default:true"`
+	ID                       uuid.UUID `gorm:"primaryKey;type:uuid;default:uuid_generate_v4()"`
+	PayloadUUID              string
+	HashedPayloadUUID        string
+	PayloadIdentifier        string
+	MobileconfigData         []byte
+	MobileconfigHash         []byte
+	OriginalMobileconfigHash []byte
+	Installed                bool `gorm:"default:true"`
 }
 
 // ProfilePayload - struct to unpack the payload sent to mdmdirector


### PR DESCRIPTION
The profile storage mutates the uploaded profile making comparisons difficult at best. This stores the original hash uploaded before mutates and exposes through a new field. This makes comparing profile sync's from CI/CD to MDMDirector easier.

  Summary of changes:                                                                                                                                                                                                                                                                                   
  - types/profile.go — added OriginalMobileconfigHash []byte to DeviceProfile and SharedProfile                                                                                                                                                                                                         
  - director/profile.go — compute MobileconfigHash from the mutated plist (restoring original behavior), and populate OriginalMobileconfigHash from the pre-mutation bytes                                                                                                                              
  - director/profile_test.go — new TestMobileconfigHashPreservesOriginalBytes test verifying the two hashes differ after UUID substitution
  
   When a mobileconfig is received by PostProfileHandler, mdmdirector intentionally mutates the plist before storing it: it replaces the caller-supplied PayloadUUID with a deterministic content-addressed UUID (uuid.NewSHA1 over the raw bytes). The stored MobileconfigData is therefore
   not the same bytes the caller sent.                                          
                                                                                     
  The original MobileconfigHash was computed from those mutated bytes. That means a caller who holds their original mobileconfig cannot independently reproduce the hash — they'd need to know the post-mutation UUID, re-serialize the plist in exactly the same way, and then hash it.   
  That's fragile and not something an external caller can easily do.
                                                                                                                                                                                                                                                                                           
  The practical consequence: there's no reliable way to answer "is the profile mdmdirector has stored the same one I submitted?" from the caller's side. This matters for any integrity check, audit, or reconciliation workflow where an operator or upstream system wants to verify the  
  stored profile matches the original submission without re-fetching it and comparing bytes.
                                                                                                                                                                                                                                                                                           
  OriginalMobileconfigHash fixes this by recording the SHA-256 of the bytes as received, before any mutation. A caller hashes what they sent, compares against OriginalMobileconfigHash, and gets a definitive answer — independent of mdmdirector's internal UUID rewriting.