### PR TITLE
fix: ensure initial tasks run on enrollment and not silently skipped

### DIFF
--- a/director/background_tasks.go
+++ b/director/background_tasks.go
@@ -188,7 +188,6 @@ func fetchDevicesFromNanoMDM(nanoClient *mdm.NanoMDMClient) {
 		if enrollment.Enabled {
 			device.AuthenticateRecieved = true
 			device.TokenUpdateRecieved = true
-			device.InitialTasksRun = true
 		}
 
 		devices = append(devices, device)
@@ -216,7 +215,6 @@ func fetchDevicesFromNanoMDM(nanoClient *mdm.NanoMDMClient) {
 			"serial_number",
 			"authenticate_recieved",
 			"token_update_recieved",
-			"initial_tasks_run",
 		}),
 	}).CreateInBatches(devices, batchSize).Error
 

--- a/director/initial_tasks.go
+++ b/director/initial_tasks.go
@@ -37,6 +37,11 @@ func RunInitialTasks(udid string) error {
 	// 	return nil
 	// }
 
+	err = RequestAllDeviceInfo(device)
+	if err != nil {
+		return errors.Wrap(err, "RunInitialTasks:RequestAllDeviceInfo")
+	}
+
 	_, err = InstallAllProfiles(device)
 	if err != nil {
 		return errors.Wrap(err, "RunInitialTasks:InstallAllProfiles")


### PR DESCRIPTION
  Two bugs in the nanomdm branch prevented devices from receiving info
  commands and DDM declarations after enrollment:

  1. fetchDevicesFromNanoMDM was setting initial_tasks_run=true during
     startup upsert, causing RunInitialTasks to be skipped for all
     existing devices on every restart.

  2. RunInitialTasks never called RequestAllDeviceInfo, so info commands
     (DeviceInformation, SecurityInfo, etc.) were never sent on enrollment.