### PR TITLE
fix: trigger DDM notify after PushApplicationViaDDM

### DIFF
--- a/director/ddm_app_push.go
+++ b/director/ddm_app_push.go
@@ -68,9 +68,15 @@ func PushApplicationViaDDM(client *ddm.KMFDDMClient, udid string, app types.Devi
 		return errors.Wrapf(err, "PushApplicationViaDDM: PUT set-declaration (activation) for %s on %s", app.ManifestURL, udid)
 	}
 
-	// Step 5: Associate enrollment with the set (noNotify=false - triggers DDM sync)
-	if err := client.PutEnrollmentSet(udid, udid, false); err != nil {
+	// Step 5: Associate enrollment with the set (noNotify=true - notify done explicitly in step 6)
+	if err := client.PutEnrollmentSet(udid, udid, true); err != nil {
 		return errors.Wrapf(err, "PushApplicationViaDDM: PUT enrollment-set for %s", udid)
+	}
+
+	// Step 6: Notify kmfddm to trigger DDM sync - bypasses the changed-check so the device
+	// always receives a DeclarativeManagement command regardless of prior enrollment state.
+	if err := client.NotifyEnrollment(udid); err != nil {
+		return errors.Wrapf(err, "PushApplicationViaDDM: notify enrollment for %s", udid)
 	}
 
 	return nil

--- a/director/ddm_app_push_test.go
+++ b/director/ddm_app_push_test.go
@@ -3,6 +3,7 @@ package director
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/uuid"
@@ -37,8 +38,8 @@ func TestPushApplicationViaDDM_AllNew(t *testing.T) {
 
 	// When declarations are new (304), no touch calls should be made.
 	// Expected sequence: PUT decl (package), PUT decl (activation), PUT set-decl (package),
-	// PUT set-decl (activation), PUT enrollment-set
-	assert.Len(t, *requests, 5)
+	// PUT set-decl (activation), PUT enrollment-set (nonotify=true), POST notify
+	assert.Len(t, *requests, 6)
 
 	reqs := *requests
 
@@ -74,11 +75,16 @@ func TestPushApplicationViaDDM_AllNew(t *testing.T) {
 	assert.Contains(t, reqs[3].Query, "declaration="+testActiPackID)
 	assert.Contains(t, reqs[3].Query, "nonotify=true")
 
-	// Step 5: PUT enrollment-set (noNotify=false to trigger sync)
+	// Step 5: PUT enrollment-set (nonotify=true)
 	assert.Equal(t, "PUT", reqs[4].Method)
 	assert.Equal(t, "/v1/enrollment-sets/DEVICE-UDID-1234", reqs[4].Path)
 	assert.Contains(t, reqs[4].Query, "set=DEVICE-UDID-1234")
-	assert.NotContains(t, reqs[4].Query, "nonotify=true")
+	assert.Contains(t, reqs[4].Query, "nonotify=true")
+
+	// Step 6: POST notify - triggers DDM sync unconditionally
+	assert.Equal(t, "POST", reqs[5].Method)
+	assert.Equal(t, "/v1/notify", reqs[5].Path)
+	assert.Contains(t, reqs[5].Query, "id=DEVICE-UDID-1234")
 }
 
 func TestPushApplicationViaDDM_UnchangedDeclarations_TouchCalled(t *testing.T) {
@@ -97,8 +103,8 @@ func TestPushApplicationViaDDM_UnchangedDeclarations_TouchCalled(t *testing.T) {
 	// When declarations are unchanged (304), touch calls should be made.
 	// Expected: PUT decl (package), POST touch (package), PUT decl (activation),
 	// POST touch (activation), PUT set-decl (package), PUT set-decl (activation),
-	// PUT enrollment-set
-	assert.Len(t, *requests, 7)
+	// PUT enrollment-set (nonotify=true), POST notify
+	assert.Len(t, *requests, 8)
 
 	reqs := *requests
 
@@ -127,9 +133,15 @@ func TestPushApplicationViaDDM_UnchangedDeclarations_TouchCalled(t *testing.T) {
 	assert.Equal(t, "PUT", reqs[5].Method)
 	assert.Equal(t, "/v1/set-declarations/DEVICE-UDID-1234", reqs[5].Path)
 
-	// Step 5: PUT enrollment-set
+	// Step 5: PUT enrollment-set (nonotify=true)
 	assert.Equal(t, "PUT", reqs[6].Method)
 	assert.Equal(t, "/v1/enrollment-sets/DEVICE-UDID-1234", reqs[6].Path)
+	assert.Contains(t, reqs[6].Query, "nonotify=true")
+
+	// Step 6: POST notify
+	assert.Equal(t, "POST", reqs[7].Method)
+	assert.Equal(t, "/v1/notify", reqs[7].Path)
+	assert.Contains(t, reqs[7].Query, "id=DEVICE-UDID-1234")
 }
 
 func TestPushApplicationViaDDM_ActivationReferencesPackageDeclaration(t *testing.T) {
@@ -208,4 +220,23 @@ func TestPushApplicationViaDDM_TouchError(t *testing.T) {
 	err := PushApplicationViaDDM(client, "DEVICE-UDID-1234", app)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "touch Package declaration")
+}
+
+func TestPushApplicationViaDDM_NotifyError(t *testing.T) {
+	// Build a server that succeeds for all steps but returns 500 for POST /v1/notify
+	notifyErrServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/v1/notify" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer notifyErrServer.Close()
+
+	client := ddm.NewKMFDDMClient(notifyErrServer.URL, "testapikey")
+	app := newTestApp("https://example.com/app.plist")
+
+	err := PushApplicationViaDDM(client, "DEVICE-UDID-1234", app)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "notify enrollment")
 }


### PR DESCRIPTION
## Summary

Applies the same step 5 / step 6 notify pattern from `PushProfileViaDDM` and `DeleteProfileViaDDM` (introduced in #136) to `PushApplicationViaDDM`.

Without this, DDM-based application installs hit the same kmfddm changed-only-notify bug: on re-enrollment with the same UDID, the enrollment-set association already exists, kmfddm returns "unchanged", and the device never receives a `DeclarativeManagement` command.

### Changes
- `director/ddm_app_push.go`: step 5 `PutEnrollmentSet` now uses `noNotify=true`; step 6 added — explicit `client.NotifyEnrollment(udid)` to trigger DDM sync unconditionally.
- `director/ddm_app_push_test.go`: updated request-count expectations (5 → 6, 7 → 8), added `nonotify=true` and `POST /v1/notify` assertions, plus a new `TestPushApplicationViaDDM_NotifyError` test.

## Test plan

- [x] `go test ./director/ -run TestPushApplicationViaDDM` — all 7 tests pass
- [x] `go test ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)