### PR TITLE
[MDMv2] add InstallBehaviour to DDM package declaration payload

### DIFF
--- a/ddm/types.go
+++ b/ddm/types.go
@@ -28,5 +28,13 @@ type ActivationSimplePayload struct {
 
 // PackagePayload is the Payload for a com.apple.configuration.package declaration
 type PackagePayload struct {
-	ManifestURL string `json:"ManifestURL"`
+	ManifestURL     string                 `json:"ManifestURL"`
+	InstallBehavior PackageInstallBehavior `json:"InstallBehavior"`
+}
+
+// PackageInstallBehavior controls how the device installs the package.
+// Install: "Required" → auto-install after activation.
+// Install: "Optional" → stage as available, user-triggered install.
+type PackageInstallBehavior struct {
+	Install string `json:"Install"`
 }

--- a/director/ddm_app_push.go
+++ b/director/ddm_app_push.go
@@ -21,7 +21,8 @@ func PushApplicationViaDDM(client *ddm.KMFDDMClient, udid string, app types.Devi
 		Identifier: packageDeclID,
 		Type:       ddm.TypePackage,
 		Payload: ddm.PackagePayload{
-			ManifestURL: app.ManifestURL,
+			ManifestURL:     app.ManifestURL,
+			InstallBehavior: ddm.PackageInstallBehavior{Install: "Required"},
 		},
 	}
 

--- a/director/ddm_app_push_test.go
+++ b/director/ddm_app_push_test.go
@@ -181,14 +181,19 @@ func TestPushApplicationViaDDM_PackagePayloadContainsManifestURL(t *testing.T) {
 
 	reqs := *requests
 	// Parse the package declaration to verify it contains the manifest URL
+	// and the InstallBehavior.Install=Required key required for auto-install.
 	var payload struct {
 		Payload struct {
-			ManifestURL string `json:"ManifestURL"`
+			ManifestURL     string `json:"ManifestURL"`
+			InstallBehavior struct {
+				Install string `json:"Install"`
+			} `json:"InstallBehavior"`
 		} `json:"Payload"`
 	}
 	err = json.Unmarshal([]byte(reqs[0].Body), &payload)
 	require.NoError(t, err)
 	assert.Equal(t, "https://example.com/myapp.plist", payload.Payload.ManifestURL)
+	assert.Equal(t, "Required", payload.Payload.InstallBehavior.Install)
 }
 
 func TestPushApplicationViaDDM_PutDeclarationError(t *testing.T) {


### PR DESCRIPTION
Adds InstallBehavior.Install = "Required" to the com.apple.configuration.package DDM declaration payload. Without this field, Apple devices stage the package as available but do not auto-install it — causing silent no-ops when pushing apps via DDM. This change ensures packages are automatically installed upon activation.