### PR TITLE
[MDMv2] fix: to not drop device acks when initial tasks are running

### DIFF
--- a/director/webhook.go
+++ b/director/webhook.go
@@ -60,26 +60,24 @@ func WebhookHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // reconcileDeviceState handles post-enrollment lifecycle transitions after any device event
-// Returns (true, nil) if RunInitialTasks was triggered - caller must return immediately
-// Returns (false, err) if SendDeviceConfigured failed - caller must propagate the error
-func reconcileDeviceState(device types.Device, currentDevice *types.Device) (bool, error) {
+func reconcileDeviceState(device types.Device, currentDevice *types.Device) error {
 	if !currentDevice.InitialTasksRun && currentDevice.TokenUpdateRecieved {
 		InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Running initial tasks"})
 		if err := RunInitialTasks(device.UDID); err != nil {
 			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
-			return true, err
+			return err
 		}
-		return true, nil
+		return nil
 	}
 
 	if currentDevice.AwaitingConfiguration && currentDevice.InitialTasksRun {
 		if err := SendDeviceConfigured(*currentDevice); err != nil {
 			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
-			return false, err
+			return err
 		}
 	}
 
-	return false, nil
+	return nil
 }
 
 func handleCheckinEvent(topic string, event *types.CheckinEvent) error {
@@ -118,7 +116,7 @@ func handleCheckinEvent(topic string, event *types.CheckinEvent) error {
 		return err
 	}
 
-	if done, err := reconcileDeviceState(device, currentDevice); done || err != nil {
+	if err := reconcileDeviceState(device, currentDevice); err != nil {
 		return err
 	}
 
@@ -151,7 +149,7 @@ func handleAcknowledgeEvent(event *types.AcknowledgeEvent) error {
 		return err
 	}
 
-	if done, err := reconcileDeviceState(device, currentDevice); done || err != nil {
+	if err := reconcileDeviceState(device, currentDevice); err != nil {
 		return err
 	}
 

--- a/director/webhook_test.go
+++ b/director/webhook_test.go
@@ -45,9 +45,8 @@ func TestReconcileDeviceState_NeitherConditionMet(t *testing.T) {
 		AwaitingConfiguration: false,
 	}
 
-	done, err := reconcileDeviceState(device, currentDevice)
+	err := reconcileDeviceState(device, currentDevice)
 
-	assert.False(t, done)
 	assert.NoError(t, err)
 }
 
@@ -59,9 +58,8 @@ func TestReconcileDeviceState_TokenUpdateNotReceived(t *testing.T) {
 		TokenUpdateRecieved: false,
 	}
 
-	done, err := reconcileDeviceState(device, currentDevice)
+	err := reconcileDeviceState(device, currentDevice)
 
-	assert.False(t, done)
 	assert.NoError(t, err)
 }
 
@@ -73,9 +71,8 @@ func TestReconcileDeviceState_InitialTasksAlreadyRun(t *testing.T) {
 		TokenUpdateRecieved: true,
 	}
 
-	done, err := reconcileDeviceState(device, currentDevice)
+	err := reconcileDeviceState(device, currentDevice)
 
-	assert.False(t, done)
 	assert.NoError(t, err)
 }
 
@@ -87,9 +84,8 @@ func TestReconcileDeviceState_NotAwaitingConfiguration(t *testing.T) {
 		AwaitingConfiguration: false,
 	}
 
-	done, err := reconcileDeviceState(device, currentDevice)
+	err := reconcileDeviceState(device, currentDevice)
 
-	assert.False(t, done)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
fix: to not drop device acks when initial tasks are running

- during enrollment, when 'RunInitialTasks' is running, the webhook handler was returning early on every incoming ack. Previously, when it fired `RunInitialTasks`, `handleAcknowledgeEvent` returned early and silently skipped `UpdateCommand`, the `Idle`-driven `RequestDeviceUpdate`, and `processAcknowledgePayload` for any ack that arrived during the enrollment burst window.

- fix: updating the behaviour from reconcileDeviceState function, to continue even if RunInitialTasks is false.

(this behaviour is currently in prod as well)