### PR TITLE
[MDMv2] fix: decode caller's base64 payload before plist marshal in nanomdm Enqueue

### DIFF
--- a/mdm/enqueue.go
+++ b/mdm/enqueue.go
@@ -2,6 +2,7 @@ package mdm
 
 import (
 	"bytes"
+	"encoding/base64"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -29,8 +30,16 @@ func (c *NanoMDMClient) Enqueue(enrollmentIDs []string, payload types.CommandPay
 		},
 	}
 
+	// Callers pass Payload base64-encoded — historically required so it could travel as JSON to micromdm,
+	// which then base64-decoded it before building the plist.
+	// nanomdm has no such decode step: we need to build the plist here.
+	// So, undo the caller's base64 first, and pass plist directly
 	if payload.Payload != "" {
-		mdmCmd.Command.Payload = []byte(payload.Payload)
+		raw, err := base64.StdEncoding.DecodeString(payload.Payload)
+		if err != nil {
+			return nil, errors.Wrap(err, "Enqueue: decode payload")
+		}
+		mdmCmd.Command.Payload = raw
 	}
 
 	plistData, err := plist.MarshalIndent(mdmCmd, "\t")

--- a/mdm/nanomdm_test.go
+++ b/mdm/nanomdm_test.go
@@ -1,6 +1,7 @@
 package mdm
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/groob/plist"
 	"github.com/mdmdirector/mdmdirector/types"
 	"github.com/mdmdirector/mdmdirector/utils"
 	"github.com/stretchr/testify/assert"
@@ -223,6 +225,52 @@ func TestNanoMDMClient_Enqueue(t *testing.T) {
 		_, err := client.Enqueue([]string{}, types.CommandPayload{}, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no enrollment IDs provided")
+	})
+
+	t.Run("InstallProfile payload is base64-encoded exactly once on the wire", func(t *testing.T) {
+		// The mobileconfig bytes any caller would have produced.
+		rawMobileconfig := []byte(`<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict><key>PayloadType</key><string>Configuration</string></dict></plist>`)
+
+		// Callers (e.g. director/profile.go) hand us the already-base64'd string.
+		callerPayload := base64.StdEncoding.EncodeToString(rawMobileconfig)
+
+		var capturedBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(APIResponse{CommandUUID: "cmd-1"})
+		}))
+		defer server.Close()
+
+		client := createTestClient(server.URL, "test-key")
+
+		_, err := client.Enqueue([]string{"device-123"}, types.CommandPayload{
+			UDID:        "device-123",
+			RequestType: "InstallProfile",
+			Payload:     callerPayload,
+		}, nil)
+		require.NoError(t, err)
+
+		// Decode the on-wire plist exactly the way macOS does, and assert that
+		// the <data> in <key>Payload</key> decodes to the original mobileconfig.
+		// If the producer's base64 wasn't decoded in Enqueue, this round-trip
+		// would yield `callerPayload` (a base64 string) instead of `rawMobileconfig`.
+		var decoded MDMCommandPlist
+		require.NoError(t, plist.Unmarshal(capturedBody, &decoded))
+		assert.Equal(t, "InstallProfile", decoded.Command.RequestType)
+		assert.Equal(t, rawMobileconfig, decoded.Command.Payload,
+			"<data> on the wire must decode to the raw mobileconfig (no double-base64)")
+	})
+
+	t.Run("invalid base64 payload returns error", func(t *testing.T) {
+		client := createTestClient("https://example.com", "key")
+
+		_, err := client.Enqueue([]string{"device-123"}, types.CommandPayload{
+			RequestType: "InstallProfile",
+			Payload:     "!!!not-base64!!!",
+		}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode payload")
 	})
 }
 


### PR DESCRIPTION
InstallProfile MDM commands sent through nanomdm path were failing on device, as they were arriving on device with two layers of base64 around the mobileconfig. 
- Fix: in mdm/Enqueue, decode payload.Payload from base64 before assigning it to MDMCommand.Payload []byte. The plist marshaller then performs the single base64 step it owns (writing []byte as <data>). 

- with micromdm, we were sending base64 string in JSON to micromdm, micromdm server then decoded it before building the plist. After migration to nanomdm, mdmdirector constructs the plist itself.