### PR TITLE
[MDMv2] fix: InstallAppInQueue references non-existent commands.data column

### DIFF
--- a/director/command.go
+++ b/director/command.go
@@ -264,11 +264,11 @@ func CommandInQueue(device types.Device, command string, afterDate time.Time) bo
 	return true
 }
 
-func InstallAppInQueue(device types.Device, data string) (bool, error) {
+func InstallAppInQueue(device types.Device, manifestURL string) (bool, error) {
 	var commandModel types.Command
 
 	err := db.DB.Model(&commandModel).
-		Where("device_ud_id = ? AND request_type = ? AND data = ?", device.UDID, "InstallApplication", data).
+		Where("device_ud_id = ? AND request_type = ? AND manifest_url = ?", device.UDID, "InstallApplication", manifestURL).
 		Where("status = ? OR status = ?", "", "NotNow").
 		First(&commandModel).
 		Error


### PR DESCRIPTION
`InstallAppInQueue` in `director/command.go` queries a `data` column on the `commands` table that no longer exists in the `Command` struct. On any Postgres instance that wasn't migrated under the old schema, the query fails with:
  ERROR: column "data" does not exist (SQLSTATE 42703)
  This silently breaks the single-device `/installapplication` path.

- Fix: Rename the parameter from `data` to `manifestURL` and update the WHERE clause to query `manifest_url` — the actual column GORM creates for the `ManifestURL string` field on `types.Command`.