### PR TITLE
[MDMv2] fix: pushOnNewBuild compares stale build, never re-pushes on OS upgrade

### DIFF
--- a/director/webhook.go
+++ b/director/webhook.go
@@ -95,7 +95,8 @@ func handleCheckinEvent(topic string, event *types.CheckinEvent) error {
 	}
 
 	device.Active = true
-	oldBuild := device.BuildVersion
+	oldBuild := previousBuildVersion(device.UDID)
+	newBuild := device.BuildVersion
 
 	switch topic {
 	case "mdm.Authenticate":
@@ -120,11 +121,9 @@ func handleCheckinEvent(topic string, event *types.CheckinEvent) error {
 		return err
 	}
 
-	if utils.PushOnNewBuild() {
-		if err := pushOnNewBuild(device.UDID, oldBuild); err != nil {
-			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
-			return err
-		}
+	if err := pushOnNewBuild(*currentDevice, oldBuild, newBuild); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+		return err
 	}
 
 	return nil
@@ -143,6 +142,9 @@ func handleAcknowledgeEvent(event *types.AcknowledgeEvent) error {
 	}
 
 	device.Active = true
+	oldBuild := previousBuildVersion(device.UDID)
+	newBuild := device.BuildVersion
+
 	currentDevice, err := UpdateDevice(device)
 	if err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
@@ -153,12 +155,9 @@ func handleAcknowledgeEvent(event *types.AcknowledgeEvent) error {
 		return err
 	}
 
-	oldBuild := device.BuildVersion
-	if utils.PushOnNewBuild() {
-		if err := pushOnNewBuild(device.UDID, oldBuild); err != nil {
-			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
-			return err
-		}
+	if err := pushOnNewBuild(*currentDevice, oldBuild, newBuild); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+		return err
 	}
 
 	if event.CommandUUID != "" {
@@ -271,37 +270,42 @@ func RequestDeviceUpdate(device types.Device) {
 	// PushDevice(device.UDID)
 }
 
-func pushOnNewBuild(udid string, currentBuild string) error {
-	// Only compare if there is actually a build version set
-	var err error
-	if udid == "" {
-		err = fmt.Errorf("device does not have a udid set %v", udid)
-		return errors.Wrap(err, "No Device UDID set")
-	}
-
-	oldDevice, err := GetDevice(udid)
+// previousBuildVersion returns the BuildVersion currently persisted for the given UDID
+// returns "" if the device is unknown (first enrollment) or the row can't be loaded
+func previousBuildVersion(udid string) string {
+	existing, err := GetDevice(udid)
 	if err != nil {
-		return errors.Wrap(err, "push on new build")
+		return ""
 	}
-	if oldDevice.BuildVersion != "" {
-		if currentBuild != "" {
-			oldVersion, err := version.NewVersion(oldDevice.BuildVersion)
-			if err != nil {
-				return err
-			}
-			currentVersion, err := version.NewVersion(currentBuild)
-			if err != nil {
-				return err
-			}
+	return existing.BuildVersion
+}
 
-			if oldVersion.LessThan(currentVersion) {
-				_, err = InstallAllProfiles(oldDevice)
-				if err != nil {
-					ErrorLogger(LogHolder{Message: err.Error()})
-				}
-			}
-		}
+// pushOnNewBuild re-pushes all profiles when the device's BuildVersion has moved forward (e.g. macOS upgrade).
+func pushOnNewBuild(device types.Device, oldBuild string, newBuild string) error {
+	if !utils.PushOnNewBuild() {
+		return nil
+	}
+	if device.UDID == "" {
+		return errors.Wrap(fmt.Errorf("device does not have a udid set"), "No Device UDID set")
+	}
+	if oldBuild == "" || newBuild == "" {
+		return nil
 	}
 
+	oldVersion, err := version.NewVersion(oldBuild)
+	if err != nil {
+		return err
+	}
+	newVersion, err := version.NewVersion(newBuild)
+	if err != nil {
+		return err
+	}
+	if !oldVersion.LessThan(newVersion) {
+		return nil
+	}
+
+	if _, err := InstallAllProfiles(device); err != nil {
+		ErrorLogger(LogHolder{Message: err.Error()})
+	}
 	return nil
 }

--- a/director/webhook_test.go
+++ b/director/webhook_test.go
@@ -3,6 +3,7 @@ package director
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -280,4 +281,130 @@ func TestProcessAcknowledgePayload_QueryResponses_InvalidPlist(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "processAcknowledgePayload:QueryResponses:plist.Unmarshal")
+}
+
+// ---- previousBuildVersion -------------------------------------------------------
+
+// Unknown UDID (no row) returns "" — used by handlers to skip the build comparison
+// on first enrollment.
+func TestPreviousBuildVersion_UnknownDeviceReturnsEmpty(t *testing.T) {
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	mockSpy.ExpectQuery(`^SELECT \* FROM "devices" WHERE ud_id = \$1`).
+		WillReturnError(gorm.ErrRecordNotFound)
+
+	got := previousBuildVersion("UNKNOWN-UDID")
+
+	assert.Equal(t, "", got)
+}
+
+// Known device returns its persisted BuildVersion.
+func TestPreviousBuildVersion_KnownDeviceReturnsBuild(t *testing.T) {
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	// GetDevice chains First(...).Scan(...), which re-executes the SELECT.
+	// Both invocations need rows.
+	makeRows := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"ud_id", "build_version"}).
+			AddRow("1234-5678-123456", "25F71")
+	}
+	mockSpy.ExpectQuery(`^SELECT \* FROM "devices" WHERE ud_id = \$1`).
+		WillReturnRows(makeRows())
+	mockSpy.ExpectQuery(`^SELECT \* FROM "devices" WHERE ud_id = \$1`).
+		WillReturnRows(makeRows())
+
+	got := previousBuildVersion("1234-5678-123456")
+
+	assert.Equal(t, "25F71", got)
+}
+
+// ---- pushOnNewBuild -------------------------------------------------------------
+
+// setBoolFlag registers (idempotent) and sets a global bool flag for the
+// duration of the test. Used to drive utils.PushOnNewBuild() / utils.UseDDM().
+func setBoolFlag(t *testing.T, name string, enabled bool) {
+	t.Helper()
+	if flag.Lookup(name) == nil {
+		flag.Bool(name, enabled, "test")
+	}
+	prev := flag.Lookup(name).Value.String()
+	require.NoError(t, flag.Set(name, fmt.Sprintf("%t", enabled)))
+	t.Cleanup(func() { _ = flag.Set(name, prev) })
+}
+
+func setPushOnNewBuildFlag(t *testing.T, enabled bool) {
+	setBoolFlag(t, "push-new-build", enabled)
+}
+
+// First enrollment: no prior build to compare against → no-op, no error.
+func TestPushOnNewBuild_FirstEnrollmentNoOp(t *testing.T) {
+	setPushOnNewBuildFlag(t, true)
+
+	device := types.Device{UDID: "1234-5678-123456"}
+
+	err := pushOnNewBuild(device, "", "25F71")
+
+	assert.NoError(t, err)
+}
+
+// Same build on both sides (the original bug pattern): no-op, no error,
+// no profile push attempted.
+func TestPushOnNewBuild_SameBuildNoOp(t *testing.T) {
+	setPushOnNewBuildFlag(t, true)
+
+	device := types.Device{UDID: "1234-5678-123456"}
+
+	err := pushOnNewBuild(device, "25F71", "25F71")
+
+	assert.NoError(t, err)
+}
+
+// Apparent downgrade: skipped (avoids spurious re-pushes from synthetic webhooks
+// or rollback scenarios).
+func TestPushOnNewBuild_DowngradeNoOp(t *testing.T) {
+	setPushOnNewBuildFlag(t, true)
+
+	device := types.Device{UDID: "1234-5678-123456"}
+
+	err := pushOnNewBuild(device, "26Z99", "25F71")
+
+	assert.NoError(t, err)
+}
+
+// Build upgrade triggers InstallAllProfiles. Asserted by observing that
+// InstallAllProfiles' first query (device-specific profiles by UDID) was
+// issued — proves the version-comparison branch fired. We let every query
+// fail; pushOnNewBuild swallows the resulting error and returns nil, which
+// matches its production contract (errors logged, not propagated).
+func TestPushOnNewBuild_BuildUpgradeTriggersInstall(t *testing.T) {
+	setPushOnNewBuildFlag(t, true)
+	setBoolFlag(t, "use-ddm", false) // InstallAllProfiles reads utils.UseDDM()
+
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	mockSpy.MatchExpectationsInOrder(false)
+	deviceProfilesQuery := mockSpy.ExpectQuery(`^SELECT \* FROM "device_profiles" WHERE device_ud_id = \$1`).
+		WithArgs("1234-5678-123456").
+		WillReturnError(errDBGoneAway)
+	// Allow any number of follow-up queries (shared profiles, RequestProfileList)
+	// to fail without failing the test — only the device_profiles query is
+	// load-bearing for the assertion.
+	mockSpy.ExpectQuery(`.*`).WillReturnError(errDBGoneAway)
+	mockSpy.ExpectQuery(`.*`).WillReturnError(errDBGoneAway)
+
+	device := types.Device{UDID: "1234-5678-123456"}
+
+	err := pushOnNewBuild(device, "25F71", "26Z99")
+
+	assert.NoError(t, err)
+	require.NotNil(t, deviceProfilesQuery, "device_profiles query must have been registered")
 }

--- a/director/webhook_test.go
+++ b/director/webhook_test.go
@@ -338,13 +338,13 @@ func setBoolFlag(t *testing.T, name string, enabled bool) {
 	t.Cleanup(func() { _ = flag.Set(name, prev) })
 }
 
-func setPushOnNewBuildFlag(t *testing.T, enabled bool) {
-	setBoolFlag(t, "push-new-build", enabled)
+func setPushOnNewBuildFlag(t *testing.T) {
+	setBoolFlag(t, "push-new-build", true)
 }
 
 // First enrollment: no prior build to compare against → no-op, no error.
 func TestPushOnNewBuild_FirstEnrollmentNoOp(t *testing.T) {
-	setPushOnNewBuildFlag(t, true)
+	setPushOnNewBuildFlag(t)
 
 	device := types.Device{UDID: "1234-5678-123456"}
 
@@ -356,7 +356,7 @@ func TestPushOnNewBuild_FirstEnrollmentNoOp(t *testing.T) {
 // Same build on both sides (the original bug pattern): no-op, no error,
 // no profile push attempted.
 func TestPushOnNewBuild_SameBuildNoOp(t *testing.T) {
-	setPushOnNewBuildFlag(t, true)
+	setPushOnNewBuildFlag(t)
 
 	device := types.Device{UDID: "1234-5678-123456"}
 
@@ -368,7 +368,7 @@ func TestPushOnNewBuild_SameBuildNoOp(t *testing.T) {
 // Apparent downgrade: skipped (avoids spurious re-pushes from synthetic webhooks
 // or rollback scenarios).
 func TestPushOnNewBuild_DowngradeNoOp(t *testing.T) {
-	setPushOnNewBuildFlag(t, true)
+	setPushOnNewBuildFlag(t)
 
 	device := types.Device{UDID: "1234-5678-123456"}
 
@@ -383,7 +383,7 @@ func TestPushOnNewBuild_DowngradeNoOp(t *testing.T) {
 // fail; pushOnNewBuild swallows the resulting error and returns nil, which
 // matches its production contract (errors logged, not propagated).
 func TestPushOnNewBuild_BuildUpgradeTriggersInstall(t *testing.T) {
-	setPushOnNewBuildFlag(t, true)
+	setPushOnNewBuildFlag(t)
 	setBoolFlag(t, "use-ddm", false) // InstallAllProfiles reads utils.UseDDM()
 
 	postgresMock, mockSpy, _ := sqlmock.New()


### PR DESCRIPTION
'pushOnNewBuild' function was't working. It was reading 'oldBuild' from the incoming payload - already the new version, and then UpdateDevice wrote that to the DB, and then pushOnNewBuild re-read the device from the DB - so 'old' and 'new' were the same value, and 'InstallAllProfiles' never fired. 

Fix: read the previous BuildVersion from the DB before UpdateDevice runs, and pass both old and new build versions to pushOnNewBuild. Dropped the redundant GetDevice call in function.