### PR TITLE
[MDMv2] fix RunInitialTasks function's race condition 

### DIFF
--- a/director/initial_tasks.go
+++ b/director/initial_tasks.go
@@ -6,7 +6,41 @@ import (
 	"github.com/mdmdirector/mdmdirector/db"
 	"github.com/mdmdirector/mdmdirector/types"
 	"github.com/pkg/errors"
+	"gorm.io/gorm"
 )
+
+// initialTasksLeaseTTL- maximum time RunInitialTasks is presumed before another caller may take the lease
+const initialTasksLeaseTTL = "5 minutes"
+
+// tryAcquireInitialTasksLease attempts to atomically claim the RunInitialTasks lease for this UDID
+// Returns true if the caller now owns the lease, false if another invocation holds it
+func tryAcquireInitialTasksLease(udid string) (bool, error) {
+	res := db.DB.Exec(`
+		UPDATE devices
+		SET    run_initial_tasks_starttime = NOW()
+		WHERE  ud_id = ?
+		  AND  initial_tasks_run = false
+		  AND  ( run_initial_tasks_starttime IS NULL
+				 OR run_initial_tasks_starttime < NOW() - INTERVAL '`+initialTasksLeaseTTL+`' )
+	`, udid)
+	if res.Error != nil {
+		return false, errors.Wrap(res.Error, "tryAcquireInitialTasksLease")
+	}
+	return res.RowsAffected == 1, nil
+}
+
+// releaseInitialTasksLease clears the lease so a retry isn't blocked for the full TTL
+func releaseInitialTasksLease(udid string) {
+	err := db.DB.Exec(`
+		UPDATE devices
+		SET    run_initial_tasks_starttime = NULL
+		WHERE  ud_id = ?
+		  AND  initial_tasks_run = false
+	`, udid).Error
+	if err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: errors.Wrap(err, "releaseInitialTasksLease").Error()})
+	}
+}
 
 func RunInitialTasks(udid string) error {
 	if udid == "" {
@@ -14,28 +48,31 @@ func RunInitialTasks(udid string) error {
 		return errors.Wrap(err, "RunInitialTasks")
 	}
 
+	acquired, err := tryAcquireInitialTasksLease(udid)
+	if err != nil {
+		return errors.Wrap(err, "RunInitialTasks")
+	}
+	if !acquired {
+		InfoLogger(LogHolder{DeviceUDID: udid, Message: "RunInitialTasks lease not acquired - already running or already complete; skipping"})
+		return nil
+	}
+
+	completed := false
+	defer func() {
+		if !completed {
+			releaseInitialTasksLease(udid)
+		}
+	}()
+
 	device, err := GetDevice(udid)
 	if err != nil {
 		return errors.Wrap(err, "RunInitialTasks")
 	}
-	// if device.InitialTasksRun == true {
-	// 	log.Infof("Initial tasks already run for %v", device.UDID)
-	// 	return nil
-	// }
 	InfoLogger(LogHolder{Message: "Running initial tasks", DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID})
 	err = ClearCommands(&device)
 	if err != nil {
 		return err
 	}
-
-	// if device.Erase || device.Lock {
-	// 	// Got a device checking in that should be wiped or locked. Make it so.
-	// 	err = EraseLockDevice(&device)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	return nil
-	// }
 
 	err = RequestAllDeviceInfo(device)
 	if err != nil {
@@ -56,6 +93,8 @@ func RunInitialTasks(udid string) error {
 		return errors.Wrap(err, "RunInitialTasks:processDeviceConfigured")
 	}
 
+	// processDeviceConfigured -> SaveDeviceConfigured already set initial_tasks_run = true
+	completed = true
 	return nil
 }
 
@@ -112,20 +151,15 @@ func ResetDevice(device types.Device) error {
 		return errors.Wrap(err, "ResetDevice:ClearCommands")
 	}
 	InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Resetting device"})
-	err = db.DB.Model(&deviceModel).Where("ud_id = ?", device.UDID).Updates(map[string]interface{}{"token_update_recieved": false, "authenticate_recieved": false, "initial_tasks_run": false, "active": false}).Error
+	err = db.DB.Model(&deviceModel).Where("ud_id = ?", device.UDID).Updates(map[string]interface{}{
+		"token_update_recieved":       false,
+		"authenticate_recieved":       false,
+		"initial_tasks_run":           false,
+		"active":                      false,
+		"run_initial_tasks_starttime": gorm.Expr("NULL"),
+	}).Error
 	if err != nil {
 		return errors.Wrap(err, "reset device")
 	}
-
-	// err = db.DB.Unscoped().Where("device_ud_id = ?", device.UDID).Delete(types.Certificate{}).Error
-	// if err != nil {
-	// 	ErrorLogger(LogHolder{Message: err.Error()})
-	// }
-
-	// err = db.DB.Unscoped().Where("device_ud_id = ?", device.UDID).Delete(types.ProfileList{}).Error
-	// if err != nil {
-	// 	ErrorLogger(LogHolder{Message: err.Error()})
-	// }
-
 	return nil
 }

--- a/director/initial_tasks_test.go
+++ b/director/initial_tasks_test.go
@@ -1,0 +1,123 @@
+package director
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testUDID = "ABCDEF12-3456-7890-ABCD-EF1234567890"
+
+// SQL fragments matched against sqlmock's regex matcher. We intentionally match
+// loosely so whitespace/formatting tweaks in the production query don't break tests.
+const (
+	acquireSQL = `UPDATE devices[\s\S]*run_initial_tasks_starttime = NOW\(\)[\s\S]*initial_tasks_run = false`
+	releaseSQL = `UPDATE devices[\s\S]*run_initial_tasks_starttime = NULL`
+)
+
+func TestTryAcquireInitialTasksLease_Acquires(t *testing.T) {
+	mock, teardown := setupMockDB(t)
+	defer teardown()
+
+	mock.ExpectExec(acquireSQL).
+		WithArgs(testUDID).
+		WillReturnResult(sqlmock.NewResult(0, 1)) // 1 row affected => acquired
+
+	got, err := tryAcquireInitialTasksLease(testUDID)
+	require.NoError(t, err)
+	assert.True(t, got, "expected lease to be acquired when 1 row updated")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTryAcquireInitialTasksLease_DeniedWhenAnotherInFlight(t *testing.T) {
+	mock, teardown := setupMockDB(t)
+	defer teardown()
+
+	mock.ExpectExec(acquireSQL).
+		WithArgs(testUDID).
+		WillReturnResult(sqlmock.NewResult(0, 0)) // 0 rows affected => someone else holds it (or already complete)
+
+	got, err := tryAcquireInitialTasksLease(testUDID)
+	require.NoError(t, err)
+	assert.False(t, got, "expected lease NOT acquired when 0 rows updated")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTryAcquireInitialTasksLease_DBError(t *testing.T) {
+	mock, teardown := setupMockDB(t)
+	defer teardown()
+
+	mock.ExpectExec(acquireSQL).
+		WithArgs(testUDID).
+		WillReturnError(errors.New("connection reset"))
+
+	got, err := tryAcquireInitialTasksLease(testUDID)
+	require.Error(t, err)
+	assert.False(t, got)
+	assert.Contains(t, err.Error(), "tryAcquireInitialTasksLease")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReleaseInitialTasksLease_ClearsTimestamp(t *testing.T) {
+	mock, teardown := setupMockDB(t)
+	defer teardown()
+
+	mock.ExpectExec(releaseSQL).
+		WithArgs(testUDID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	releaseInitialTasksLease(testUDID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestRunInitialTasks_EmptyUDIDShortCircuits ensures the empty-UDID guard fires
+// before any DB work — sqlmock would flag any unexpected query.
+func TestRunInitialTasks_EmptyUDIDShortCircuits(t *testing.T) {
+	mock, teardown := setupMockDB(t)
+	defer teardown()
+
+	err := RunInitialTasks("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "No Device UDID")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestRunInitialTasks_LeaseDeniedSkipsInnerFlow is the key behavioural test:
+// when the CAS returns 0 rows affected, RunInitialTasks must return nil
+// without invoking GetDevice / RequestAllDeviceInfo / InstallAllProfiles / etc.
+// We assert this by registering ONLY the CAS expectation in sqlmock — any
+// further DB call (which all the inner functions ultimately make) would
+// trip "unexpected query" and fail the test.
+func TestRunInitialTasks_LeaseDeniedSkipsInnerFlow(t *testing.T) {
+	mock, teardown := setupMockDB(t)
+	defer teardown()
+
+	mock.ExpectExec(acquireSQL).
+		WithArgs(testUDID).
+		WillReturnResult(sqlmock.NewResult(0, 0)) // denied
+
+	err := RunInitialTasks(testUDID)
+	require.NoError(t, err, "lease-denied path must return nil, not an error")
+	assert.NoError(t, mock.ExpectationsWereMet(),
+		"no further DB queries should run when lease is not acquired")
+}
+
+// TestRunInitialTasks_AcquireErrorPropagates verifies a CAS failure
+// is wrapped and returned, and does not silently swallow.
+func TestRunInitialTasks_AcquireErrorPropagates(t *testing.T) {
+	mock, teardown := setupMockDB(t)
+	defer teardown()
+
+	mock.ExpectExec(acquireSQL).
+		WithArgs(testUDID).
+		WillReturnError(errors.New("db down"))
+
+	err := RunInitialTasks(testUDID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RunInitialTasks")
+	assert.Contains(t, err.Error(), "db down")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/types/device.go
+++ b/types/device.go
@@ -64,27 +64,28 @@ type Device struct {
 	SupplementalBuildVersion   string
 	SupplementalOSVersionExtra string
 	// SoftwareUpdateSettings     SoftwareUpdateSettings `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
-	VoiceRoamingEnabled  bool
-	WiFiMAC              string
-	EthernetMAC          string
-	UDID                 string `gorm:"primaryKey"`
-	Active               bool
-	Profiles             []DeviceProfile            `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
-	Commands             []Command                  `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
-	Certificates         []Certificate              `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
-	InstallApplications  []DeviceInstallApplication `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
-	SecurityInfo         SecurityInfo               `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
-	ProfileList          []ProfileList              `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
-	UpdatedAt            time.Time
-	AuthenticateRecieved bool `gorm:"default:false"`
-	TokenUpdateRecieved  bool `gorm:"default:false"`
-	InitialTasksRun      bool `gorm:"default:false"`
-	Erase                bool `gorm:"default:false"`
-	Lock                 bool `gorm:"default:false"`
-	UnlockPin            string
-	TempUnlockPin        UnlockPin `gorm:"foreignKey:DeviceUDID"`
-	LastInfoRequested    time.Time
-	NextPush             time.Time
+	VoiceRoamingEnabled      bool
+	WiFiMAC                  string
+	EthernetMAC              string
+	UDID                     string `gorm:"primaryKey"`
+	Active                   bool
+	Profiles                 []DeviceProfile            `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
+	Commands                 []Command                  `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
+	Certificates             []Certificate              `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
+	InstallApplications      []DeviceInstallApplication `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
+	SecurityInfo             SecurityInfo               `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
+	ProfileList              []ProfileList              `gorm:"foreignKey:DeviceUDID" json:",omitempty"`
+	UpdatedAt                time.Time
+	AuthenticateRecieved     bool       `gorm:"default:false"`
+	TokenUpdateRecieved      bool       `gorm:"default:false"`
+	InitialTasksRun          bool       `gorm:"default:false"`
+	RunInitialTasksStarttime *time.Time `gorm:"column:run_initial_tasks_starttime"`
+	Erase                    bool       `gorm:"default:false"`
+	Lock                     bool       `gorm:"default:false"`
+	UnlockPin                string
+	TempUnlockPin            UnlockPin `gorm:"foreignKey:DeviceUDID"`
+	LastInfoRequested        time.Time
+	NextPush                 time.Time
 	// LastScheduledPush        time.Time
 	LastCheckedIn       time.Time
 	LastCertificateList time.Time


### PR DESCRIPTION
`RunInitialTasks` was firing 2-4× per device enrollment in prod because `!InitialTasksRun` at the call sites is a check-then-act race — `initial_tasks_run=true` is only persisted at the *end* of the flow. Fires cross `mdmdirector-prod-1a` and `-1c`, so a process-local mutex can't fix it.

 Fix: gate `RunInitialTasks` on a DB-level lease via a single conditional `UPDATE`. Exactly one caller wins per UDID; others return nil.
 
 ## Changes

  - New nullable column `run_initial_tasks_starttime` on `devices` (added via GORM `AutoMigrate`).
  - `tryAcquireInitialTasksLease` — single CAS `UPDATE` gated on `initial_tasks_run = false` AND (timestamp `NULL` OR older than TTL). Returns true only if rows-affected = 1.
  - `RunInitialTasks` acquires lease before any work; `defer` releases on every non-success path (incl. panics). Stale leases recoverable after TTL.
  - `ResetDevice` clears the lease so re-enrollment doesn't inherit it.