### PR TITLE
[MDMv2] Wrap re-enrollment MachineInfo header in PKCS7 (Apple Aspen format)

### DIFF
--- a/director/enrollmentwebhook_client.go
+++ b/director/enrollmentwebhook_client.go
@@ -1,11 +1,17 @@
 package director
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"io"
+	"math/big"
 	"net/http"
 	"time"
 
+	"github.com/fullsailor/pkcs7"
 	"github.com/groob/plist"
 	"github.com/mdmdirector/mdmdirector/types"
 	"github.com/mdmdirector/mdmdirector/utils"
@@ -44,7 +50,57 @@ func buildMachineInfoHeader(device types.Device) (string, error) {
 		return "", errors.Wrap(err, "marshal MachineInfo plist")
 	}
 
-	return base64.StdEncoding.EncodeToString(plistBytes), nil
+	// X-Apple-Aspen-Deviceinfo is an Apple-format PKCS7/CMS-signed plist; real
+	// devices always send it wrapped this way. We match that format so any
+	// enrollment endpoint expecting the standard header can parse it.
+	wrapped, err := wrapPKCS7(plistBytes)
+	if err != nil {
+		return "", errors.Wrap(err, "wrap MachineInfo plist in PKCS7")
+	}
+
+	return base64.StdEncoding.EncodeToString(wrapped), nil
+}
+
+// wrapPKCS7 wraps data in a PKCS7 signed-data structure using an ephemeral self-signed certificate.
+// The signature is not intended to be verified by the receiver; it exists only so the payload is valid PKCS7 DER
+func wrapPKCS7(data []byte) ([]byte, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, errors.Wrap(err, "generate signing key")
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "mdmdirector-machineinfo"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, errors.Wrap(err, "create signing certificate")
+	}
+
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse signing certificate")
+	}
+
+	sd, err := pkcs7.NewSignedData(data)
+	if err != nil {
+		return nil, errors.Wrap(err, "new signed data")
+	}
+
+	if err := sd.AddSigner(cert, priv, pkcs7.SignerInfoConfig{}); err != nil {
+		return nil, errors.Wrap(err, "add signer")
+	}
+
+	signed, err := sd.Finish()
+	if err != nil {
+		return nil, errors.Wrap(err, "finish signed data")
+	}
+
+	return signed, nil
 }
 
 // fetchEnrollmentProfileFromWebhook gets enrollment profile from the enrollment profile webhook endpoint

--- a/director/enrollmentwebhook_client_test.go
+++ b/director/enrollmentwebhook_client_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/fullsailor/pkcs7"
+	"github.com/groob/plist"
 	"github.com/mdmdirector/mdmdirector/types"
 	"github.com/micromdm/go4/env"
 	"github.com/stretchr/testify/assert"
@@ -114,10 +116,6 @@ func TestFetchEnrollmentProfileFromWebhook_DeviceInfoHeaderEncoded(t *testing.T)
 		BuildVersion: "21A329",
 	}
 
-	// Pre-compute expected header so we can compare against what the server receives.
-	expectedHeader, err := buildMachineInfoHeader(device)
-	require.NoError(t, err)
-
 	var receivedHeader string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -130,7 +128,23 @@ func TestFetchEnrollmentProfileFromWebhook_DeviceInfoHeaderEncoded(t *testing.T)
 	setFlagValue(t, "enroll-webhook-url", server.URL)
 	setFlagValue(t, "enroll-webhook-token", "tok")
 
-	_, err = fetchEnrollmentProfileFromWebhook(device)
+	_, err := fetchEnrollmentProfileFromWebhook(device)
 	require.NoError(t, err)
-	assert.Equal(t, expectedHeader, receivedHeader)
+
+	// The header must be a base64-encoded PKCS7 structure whose inner content
+	// is the MachineInfo plist. The receiving endpoint always runs pkcs7.Parse
+	// on it, so a raw plist would be rejected.
+	der, err := base64.StdEncoding.DecodeString(receivedHeader)
+	require.NoError(t, err, "header must be valid base64")
+
+	p7, err := pkcs7.Parse(der)
+	require.NoError(t, err, "header must be valid PKCS7 DER")
+
+	var info machineInfoPlist
+	err = plist.Unmarshal(p7.Content, &info)
+	require.NoError(t, err, "PKCS7 content must be a MachineInfo plist")
+
+	assert.Equal(t, device.UDID, info.UDID)
+	assert.Equal(t, device.SerialNumber, info.Serial)
+	assert.Equal(t, device.Model, info.Product)
 }


### PR DESCRIPTION
The enrollment-profile webhook re-enrollment path sends device details to the
webhook in the X-Apple-Aspen-Deviceinfo header. Per Apple's enrollment
protocol, this header is a PKCS7/CMS-signed plist — real devices always send it
wrapped this way, and enrollment endpoints parse it with pkcs7.Parse. The
previous implementation sent a bare base64 plist, which such endpoints reject.

buildMachineInfoHeader now wraps the MachineInfo plist in a PKCS7 signed-data
structure (new wrapPKCS7 helper) before base64-encoding it, producing the
standard Apple wire format so any conformant enrollment endpoint can parse it.