### PR TITLE
[MDMv2] Hydrate device in UpdateDevice and reconcileDeviceState for re-enrollment flow  

### DIFF
--- a/director/device.go
+++ b/director/device.go
@@ -31,7 +31,10 @@ func UpdateDevice(newDevice types.Device) (*types.Device, error) {
 	if newDevice.UDID != "" {
 		if err := db.DB.Where("ud_id = ?", newDevice.UDID).First(&device).Scan(&oldDevice).Error; err != nil {
 			if intErrors.Is(err, gorm.ErrRecordNotFound) {
-				db.DB.Create(&newDevice)
+				if err := db.DB.Create(&newDevice).Error; err != nil {
+					return &newDevice, errors.Wrap(err, "Update device create udid")
+				}
+				device = newDevice
 			}
 		} else {
 			err := db.DB.Model(&device).Where("ud_id = ?", newDevice.UDID).Assign(&newDevice).FirstOrCreate(&device).Error
@@ -44,7 +47,10 @@ func UpdateDevice(newDevice types.Device) (*types.Device, error) {
 	if newDevice.SerialNumber != "" {
 		if err := db.DB.Where("serial_number = ?", newDevice.SerialNumber).First(&device).Scan(&oldDevice).Error; err != nil {
 			if intErrors.Is(err, gorm.ErrRecordNotFound) {
-				db.DB.Create(&newDevice)
+				if err := db.DB.Create(&newDevice).Error; err != nil {
+					return &newDevice, errors.Wrap(err, "Update device create serial")
+				}
+				device = newDevice
 			}
 		} else {
 			err := db.DB.Model(&device).Where("serial_number = ?", newDevice.SerialNumber).Assign(&newDevice).FirstOrCreate(&device).Error

--- a/director/webhook.go
+++ b/director/webhook.go
@@ -94,11 +94,11 @@ func checkinMessageType(topic string) string {
 }
 
 // reconcileDeviceState handles post-enrollment lifecycle transitions after any device event
-func reconcileDeviceState(device types.Device, currentDevice *types.Device) error {
+func reconcileDeviceState(currentDevice *types.Device) error {
 	if !currentDevice.InitialTasksRun && currentDevice.TokenUpdateRecieved {
-		InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: "Running initial tasks"})
-		if err := RunInitialTasks(device.UDID); err != nil {
-			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+		InfoLogger(LogHolder{DeviceSerial: currentDevice.SerialNumber, DeviceUDID: currentDevice.UDID, Message: "Running initial tasks"})
+		if err := RunInitialTasks(currentDevice.UDID); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: currentDevice.UDID, DeviceSerial: currentDevice.SerialNumber, Message: err.Error()})
 			return err
 		}
 		return nil
@@ -106,7 +106,7 @@ func reconcileDeviceState(device types.Device, currentDevice *types.Device) erro
 
 	if currentDevice.AwaitingConfiguration && currentDevice.InitialTasksRun {
 		if err := SendDeviceConfigured(*currentDevice); err != nil {
-			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+			ErrorLogger(LogHolder{DeviceUDID: currentDevice.UDID, DeviceSerial: currentDevice.SerialNumber, Message: err.Error()})
 			return err
 		}
 	}
@@ -151,7 +151,7 @@ func handleCheckinEvent(topic string, event *types.CheckinEvent) error {
 		return err
 	}
 
-	if err := reconcileDeviceState(device, currentDevice); err != nil {
+	if err := reconcileDeviceState(currentDevice); err != nil {
 		return err
 	}
 
@@ -185,7 +185,7 @@ func handleAcknowledgeEvent(event *types.AcknowledgeEvent) error {
 		return err
 	}
 
-	if err := reconcileDeviceState(device, currentDevice); err != nil {
+	if err := reconcileDeviceState(currentDevice); err != nil {
 		return err
 	}
 
@@ -206,7 +206,7 @@ func handleAcknowledgeEvent(event *types.AcknowledgeEvent) error {
 		return nil
 	}
 
-	if err := processAcknowledgePayload(event, device, payloadDict); err != nil {
+	if err := processAcknowledgePayload(event, *currentDevice, payloadDict); err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
 		return err
 	}

--- a/director/webhook_test.go
+++ b/director/webhook_test.go
@@ -39,53 +39,54 @@ var errDBGoneAway = fmt.Errorf("database has gone away")
 
 // When neither trigger condition is met the function is a clean no-op.
 func TestReconcileDeviceState_NeitherConditionMet(t *testing.T) {
-	device := types.Device{UDID: "1234-5678-123456", SerialNumber: "C02ABCDEFGH"}
 	currentDevice := &types.Device{
+		UDID:                  "1234-5678-123456",
+		SerialNumber:          "C02ABCDEFGH",
 		InitialTasksRun:       true,
 		TokenUpdateRecieved:   true,
 		AwaitingConfiguration: false,
 	}
 
-	err := reconcileDeviceState(device, currentDevice)
+	err := reconcileDeviceState(currentDevice)
 
 	assert.NoError(t, err)
 }
 
 // TokenUpdateRecieved=false → RunInitialTasks must NOT be triggered.
 func TestReconcileDeviceState_TokenUpdateNotReceived(t *testing.T) {
-	device := types.Device{UDID: "1234-5678-123456"}
 	currentDevice := &types.Device{
+		UDID:                "1234-5678-123456",
 		InitialTasksRun:     false,
 		TokenUpdateRecieved: false,
 	}
 
-	err := reconcileDeviceState(device, currentDevice)
+	err := reconcileDeviceState(currentDevice)
 
 	assert.NoError(t, err)
 }
 
 // InitialTasksRun=true → the first condition is false; RunInitialTasks must NOT be re-triggered.
 func TestReconcileDeviceState_InitialTasksAlreadyRun(t *testing.T) {
-	device := types.Device{UDID: "1234-5678-123456"}
 	currentDevice := &types.Device{
+		UDID:                "1234-5678-123456",
 		InitialTasksRun:     true,
 		TokenUpdateRecieved: true,
 	}
 
-	err := reconcileDeviceState(device, currentDevice)
+	err := reconcileDeviceState(currentDevice)
 
 	assert.NoError(t, err)
 }
 
 // AwaitingConfiguration=false → SendDeviceConfigured must NOT be called even when InitialTasksRun=true.
 func TestReconcileDeviceState_NotAwaitingConfiguration(t *testing.T) {
-	device := types.Device{UDID: "1234-5678-123456"}
 	currentDevice := &types.Device{
+		UDID:                  "1234-5678-123456",
 		InitialTasksRun:       true,
 		AwaitingConfiguration: false,
 	}
 
-	err := reconcileDeviceState(device, currentDevice)
+	err := reconcileDeviceState(currentDevice)
 
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## What
- `UpdateDevice`: on first enrollment, assign the freshly-created row back into the returned device so callers always get a populated `*types.Device` instead of a zero-valued struct. Also stop swallowing the `Create` error.
- `reconcileDeviceState`: drop the redundant sparse `device` param and read everything from the DB-hydrated `currentDevice`.

## Why
A `CertificateList`/`ProfileList` ack from nanomdm only carries the UDID — `SerialNumber`/`Model` are empty. Those acks feed the enrollment-webhook MachineInfo header (`buildMachineInfoHeader`), which needs `SERIAL`/`PRODUCT`. Routing through the hydrated `currentDevice` ensures downstream consumers get real device attributes.