### PR TITLE
[MDMv2]  persist device profile to DB before pushing via DDM

### DIFF
--- a/director/profile.go
+++ b/director/profile.go
@@ -295,15 +295,20 @@ func ProcessDeviceProfiles(
 			}
 			profile.Installed = true
 			if profileDiffers {
-				profilesToSave = append(profilesToSave, profile)
 				status = "changed"
 				if pushNow {
+					// Persist the profile before pushing as in DDM flow the device fetches the mobileconfig from /profiledownload
+					// using the ProfileURL in the declaration, so the row must already be in DB
+					if err := SaveProfiles([]types.Device{device}, []types.DeviceProfile{profile}); err != nil {
+						return metadata, errors.Wrap(err, "Save profile before push")
+					}
 					_, err = PushProfiles(devices, []types.DeviceProfile{profile}, utils.UseDDM())
 					if err != nil {
 						ErrorLogger(LogHolder{Message: err.Error()})
 					}
 					status = "pushed"
 				} else {
+					profilesToSave = append(profilesToSave, profile)
 					status = "saved"
 				}
 			}


### PR DESCRIPTION
Fixes a race condition in the device-profile `POST /profile` push flow where
the profile was saved to the database *after* the push was issued.

In the DDM flow, the device fetches the mobileconfig from
`GET /profiledownload/{udid}/{profileIdentifier}` using the `ProfileURL`
embedded in the `LegacyProfile` declaration. That handler reads the row from
the DB via `findMobileconfigData` and requires `Installed == true`. Because
`ProcessDeviceProfiles` previously deferred the DB write (`SaveProfiles`) until
after the per-profile loop — i.e. after `PushProfiles` → `PushProfileViaDDM` →
`NotifyEnrollment` had already triggered the DDM sync — the device could hit
`/profiledownload` before the row was committed:

- **New profile:** lookup returns `ErrRecordNotFound` → `404`, only succeeding
  on a later retry.
- **Updated profile:** device could download the **stale** mobileconfig before
  the `Save` overwrote it.

## Change

In the `pushNow` branch of `ProcessDeviceProfiles`, save the profile (with
`Installed=true`) to the DB **before** calling `PushProfiles`, so any
`ProfileURL` handed to kmfddm is always backed by committed data. Profiles in
this branch are no longer appended to the deferred `profilesToSave` batch, so
there's no double-save. The `pushNow=false` path is unchanged.