### PR TITLE
[MDMv2] Dual-write NanoMDM checkins to MicroMDM for migration rollback safety

### DIFF
--- a/director/background_tasks.go
+++ b/director/background_tasks.go
@@ -107,14 +107,14 @@ func FetchDevicesFromMDM() {
 		Timeout: time.Second * 60,
 	}
 
-	endpoint, err := url.Parse(utils.ServerURL())
+	endpoint, err := url.Parse(utils.MicroMDMURL())
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
 	endpoint.Path = path.Join(endpoint.Path, "v1", "devices")
 
 	req, _ := http.NewRequest("POST", endpoint.String(), bytes.NewBufferString("{}"))
-	req.SetBasicAuth("micromdm", utils.APIKey())
+	req.SetBasicAuth("micromdm", utils.MicroMDMAPIKey())
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})

--- a/director/command.go
+++ b/director/command.go
@@ -52,9 +52,9 @@ func SendCommand(commandPayload types.CommandPayload) (types.Command, error) {
 	if err != nil {
 		return command, err
 	}
-	req, _ := http.NewRequest("POST", utils.ServerURL()+"/v1/commands", bytes.NewBuffer(jsonStr))
+	req, _ := http.NewRequest("POST", utils.MicroMDMURL()+"/v1/commands", bytes.NewBuffer(jsonStr))
 
-	req.SetBasicAuth("micromdm", utils.APIKey())
+	req.SetBasicAuth("micromdm", utils.MicroMDMAPIKey())
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -444,7 +444,7 @@ func clearCommandQueue(device types.Device) error {
 		Timeout: time.Second * 1,
 	}
 
-	endpoint, err := url.Parse(utils.ServerURL())
+	endpoint, err := url.Parse(utils.MicroMDMURL())
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func clearCommandQueue(device types.Device) error {
 	endpoint.Path = path.Join(endpoint.Path, "v1", "commands", device.UDID)
 
 	req, _ := http.NewRequest("DELETE", endpoint.String(), bytes.NewBufferString("{}"))
-	req.SetBasicAuth("micromdm", utils.APIKey())
+	req.SetBasicAuth("micromdm", utils.MicroMDMAPIKey())
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
@@ -472,14 +472,14 @@ func InspectCommandQueue(device types.Device) ([]byte, error) {
 	}
 
 	// MicroMDM implementation
-	endpoint, err := url.Parse(utils.ServerURL())
+	endpoint, err := url.Parse(utils.MicroMDMURL())
 	if err != nil {
 		return nil, err
 	}
 
 	endpoint.Path = path.Join(endpoint.Path, "v1", "commands", device.UDID)
 	req, _ := http.NewRequest("GET", endpoint.String(), nil)
-	req.SetBasicAuth("micromdm", utils.APIKey())
+	req.SetBasicAuth("micromdm", utils.MicroMDMAPIKey())
 
 	httpClient := &http.Client{
 		Timeout: time.Second * 10,

--- a/director/migration_sync.go
+++ b/director/migration_sync.go
@@ -1,0 +1,47 @@
+package director
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
+	"github.com/mdmdirector/mdmdirector/utils"
+)
+
+var migrationSyncClient = &http.Client{Timeout: 15 * time.Second}
+
+// syncCheckinToMicroMDM mirrors a checkin event's raw plist to MicroMDM's migration-sync endpoint
+func syncCheckinToMicroMDM(topic string, rawPayload []byte) {
+	if !utils.DualWriteMicroMDM() {
+		return
+	}
+
+	go func() {
+		endpoint, err := url.Parse(utils.MicroMDMURL())
+		if err != nil {
+			ErrorLogger(LogHolder{Message: "migration dual-write to MicroMDM: " + err.Error(), Metric: topic})
+			return
+		}
+		endpoint.Path = path.Join(endpoint.Path, "mdm", "migration-checkin")
+
+		req, err := http.NewRequest(http.MethodPut, endpoint.String(), bytes.NewReader(rawPayload))
+		if err != nil {
+			ErrorLogger(LogHolder{Message: "migration dual-write to MicroMDM: " + err.Error(), Metric: topic})
+			return
+		}
+		req.SetBasicAuth("micromdm", utils.MicroMDMAPIKey())
+
+		resp, err := migrationSyncClient.Do(req)
+		if err != nil {
+			ErrorLogger(LogHolder{Message: "migration dual-write to MicroMDM failed: " + err.Error(), Metric: topic})
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			ErrorLogger(LogHolder{Message: "migration dual-write to MicroMDM returned non-200", Metric: topic})
+		}
+	}()
+}

--- a/director/schedule_push.go
+++ b/director/schedule_push.go
@@ -282,7 +282,7 @@ func PushDevice(udid string) (err error) {
 	retry := now.Add(time.Minute * time.Duration(int64(utils.OnceIn())))
 	retryUnix := retry.Unix()
 
-	endpoint, err := url.Parse(utils.ServerURL())
+	endpoint, err := url.Parse(utils.MicroMDMURL())
 	if err != nil {
 		return errors.Wrap(err, "PushDevice")
 	}
@@ -295,7 +295,7 @@ func PushDevice(udid string) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "PushDevice")
 	}
-	req.SetBasicAuth("micromdm", utils.APIKey())
+	req.SetBasicAuth("micromdm", utils.MicroMDMAPIKey())
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/director/webhook.go
+++ b/director/webhook.go
@@ -120,6 +120,9 @@ func handleCheckinEvent(topic string, event *types.CheckinEvent) error {
 		return errors.Wrap(err, "handleCheckinEvent:plist.Unmarshal")
 	}
 
+	// Migration rollback safety net: mirror this checkin into MicroMDM (fire-and-forget)
+	syncCheckinToMicroMDM(topic, event.RawPayload)
+
 	if topic == "mdm.CheckOut" {
 		if err := ResetDevice(device); err != nil {
 			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})

--- a/main.go
+++ b/main.go
@@ -74,6 +74,9 @@ var EscrowURL string
 
 var ClearDeviceOnEnroll bool
 
+// DualWriteMicroMDM mirrors every checkin webhook to MicroMDM during the NanoMDM migration
+var DualWriteMicroMDM bool
+
 var ScepCertIssuer string
 
 var ScepCertMinValidity int
@@ -406,6 +409,12 @@ func main() {
 		env.String("MDM_SERVER_TYPE", "micromdm"),
 		"MDM server type: micromdm or nanomdm",
 	)
+	flag.BoolVar(
+		&DualWriteMicroMDM,
+		"dual-write-micromdm",
+		env.Bool("DUAL_WRITE_MICROMDM", false),
+		"Mirror checkin webhooks to MicroMDM (migration rollback safety net; requires mdm-server-type=nanomdm and micromdmurl/micromdmapikey)",
+	)
 	flag.Parse()
 
 	logLevel, err := log.ParseLevel(LogLevel)
@@ -455,6 +464,16 @@ func main() {
 		}
 	default:
 		log.Fatalf("Unknown MDM server type: %s. Must be 'micromdm' or 'nanomdm'. Exiting.", MDMServerType)
+	}
+
+	if DualWriteMicroMDM {
+		if MDMServerType != string(mdm.ServerTypeNanoMDM) {
+			log.Fatal("dual-write-micromdm requires mdm-server-type=nanomdm. Exiting.")
+		}
+		if MicroMDMURL == "" || MicroMDMAPIKey == "" {
+			log.Fatal("dual-write-micromdm requires micromdmurl/micromdmapikey (MICRO_URL/MICRO_API_KEY). Exiting.")
+		}
+		log.Infof("Dual-write to MicroMDM enabled at %s", MicroMDMURL)
 	}
 
 	if EnableReEnrollViaWebhook {

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -96,6 +96,14 @@ func ClearDeviceOnEnroll() bool {
 	return flag.Lookup("clear-device-on-enroll").Value.(flag.Getter).Get().(bool)
 }
 
+func DualWriteMicroMDM() bool {
+	f := flag.Lookup("dual-write-micromdm")
+	if f == nil {
+		return false
+	}
+	return f.Value.(flag.Getter).Get().(bool)
+}
+
 func ScepCertIssuer() string {
 	return flag.Lookup("scep-cert-issuer").Value.(flag.Getter).Get().(string)
 }

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 )
 
-func ServerURL() string {
+// MicroMDMURL returns the MicroMDM server URL (flag micromdmurl / env MICRO_URL)
+func MicroMDMURL() string {
 	return strings.TrimRight(flag.Lookup("micromdmurl").Value.(flag.Getter).Get().(string), "/")
 }
 
-func APIKey() string {
+// MicroMDMAPIKey returns the MicroMDM API key (flag micromdmapikey / env MICRO_API_KEY)
+func MicroMDMAPIKey() string {
 	return flag.Lookup("micromdmapikey").Value.(flag.Getter).Get().(string)
 }
 


### PR DESCRIPTION
## Summary

Adds an opt-in dual-write path so that, during the live-fleet MicroMDM → NanoMDM
migration, mdmdirector mirrors every check-in it receives from NanoMDM back into
MicroMDM — keeping MicroMDM's enrollment/token record fresh enough to remain a safe
rollback target.

This is the **mdmdirector half** of the change; it targets the companion MicroMDM
endpoint `PUT /mdm/migration-checkin` (gated behind`-migration`).

## Why

The migration moves devices to NanoMDM via per-device DNS, and any device/cohort can be
rolled back by removing its DNS override. But once a device is on NanoMDM, its check-ins
(including a fresh `TokenUpdate` from a reboot or APNs token rotation) only reach NanoMDM —
MicroMDM's copy of the push token goes stale. If we later roll that device back, MicroMDM
would push against a stale token and the device is silently unreachable via APNs until it
happens to check in on its own