### PR TITLE
[MDMv2] Add per-device DDM opt-in for phased MicroMDM→NanoMDM migration

### DIFF
--- a/director/ddm_migration.go
+++ b/director/ddm_migration.go
@@ -1,0 +1,251 @@
+package director
+
+// -----------------------------------------------------------------------------
+// TEMPORARY — MicroMDM -> NanoMDM migration only.
+//
+// This whole file (plus the `ddm_migration_optins` table) exists so we can flip
+// individual devices (or cohorts) onto DDM independently of the global USE_DDM /
+// USE_DDM_PACKAGES switches. That lets a migration wave land on NanoMDM in the
+// classic InstallProfile / InstallApplication protocol first, and be promoted to
+// DDM later, per device.
+//
+// A single opt-in row covers BOTH profiles and applications for a device. The two
+// global flags remain independent enable-all master switches (see ddmForDevice /
+// ddmPackagesForDevice below).
+//
+// ============================ CLEANUP CHECKLIST ==============================
+// Once the whole fleet is on DDM and per-device control is no longer needed:
+//   1. Delete this file.
+//   2. Replace every call to ddmForDevice(d)        with utils.UseDDM().
+//      Replace every call to ddmPackagesForDevice(d) with utils.UseDDMPackages().
+//      Replace pushSharedProfilesPerDevice / deleteSharedProfilesPerDevice call
+//        sites with the direct PushSharedProfiles / DeleteSharedProfiles calls
+//        passing utils.UseDDM().
+//      Restore the app functions in install_application.go to branch on
+//        utils.UseDDMPackages() at the top (see the "migration" comments there).
+//   3. Remove &DDMMigrationOptIn{} from db.DB.AutoMigrate(...) in main.go and drop
+//      the two /device/{udid}/ddm-migrate routes.
+//   4. DROP TABLE ddm_migration_optins;
+// =============================================================================
+
+import (
+	"encoding/json"
+	intErrors "errors"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mdmdirector/mdmdirector/db"
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/mdmdirector/mdmdirector/utils"
+)
+
+// DDMMigrationOptIn marks a single device as opted into DDM (for both profiles and
+// applications) during the migration. Presence of a row == opted in.
+type DDMMigrationOptIn struct {
+	DeviceUDID string `gorm:"primaryKey" json:"device_udid"`
+}
+
+// TableName pins the table name so the CLEANUP "DROP TABLE" is unambiguous.
+func (DDMMigrationOptIn) TableName() string { return "ddm_migration_optins" }
+
+// deviceOptedIntoDDM reports whether a single device has been explicitly opted in.
+func deviceOptedIntoDDM(udid string) bool {
+	if udid == "" {
+		return false
+	}
+	var count int64
+	if err := db.DB.Model(&DDMMigrationOptIn{}).Where("device_udid = ?", udid).Count(&count).Error; err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "deviceOptedIntoDDM: " + err.Error()})
+		return false
+	}
+	return count > 0
+}
+
+// ddmForDevice decides whether PROFILE operations for this device use DDM
+func ddmForDevice(device types.Device) bool {
+	return utils.UseDDM() || deviceOptedIntoDDM(device.UDID)
+}
+
+// ddmPackagesForDevice decides whether APPLICATION operations for this device use DDM
+func ddmPackagesForDevice(device types.Device) bool {
+	return utils.UseDDMPackages() || deviceOptedIntoDDM(device.UDID)
+}
+
+// optedInSet loads, in a single query, the opt-in membership for the given devices
+func optedInSet(devices []types.Device) map[string]bool {
+	set := make(map[string]bool)
+	if len(devices) == 0 {
+		return set
+	}
+	udids := make([]string, 0, len(devices))
+	for i := range devices {
+		udids = append(udids, devices[i].UDID)
+	}
+	var optIns []DDMMigrationOptIn
+	if err := db.DB.Where("device_udid IN (?)", udids).Find(&optIns).Error; err != nil {
+		ErrorLogger(LogHolder{Message: "optedInSet: " + err.Error()})
+		return set
+	}
+	for _, o := range optIns {
+		set[o.DeviceUDID] = true
+	}
+	return set
+}
+
+// partitionByDDM splits devices into the DDM cohort and the classic cohort for PROFILE
+func partitionByDDM(devices []types.Device) (ddmDevices, legacyDevices []types.Device) {
+	global := utils.UseDDM()
+	set := optedInSet(devices)
+	for i := range devices {
+		if global || set[devices[i].UDID] {
+			ddmDevices = append(ddmDevices, devices[i])
+		} else {
+			legacyDevices = append(legacyDevices, devices[i])
+		}
+	}
+	return
+}
+
+// partitionByDDMPackages splits devices into the DDM cohort and the classic cohort for APPLICATION
+func partitionByDDMPackages(devices []types.Device) (ddmDevices, legacyDevices []types.Device) {
+	global := utils.UseDDMPackages()
+	set := optedInSet(devices)
+	for i := range devices {
+		if global || set[devices[i].UDID] {
+			ddmDevices = append(ddmDevices, devices[i])
+		} else {
+			legacyDevices = append(legacyDevices, devices[i])
+		}
+	}
+	return
+}
+
+// pushSharedProfilesPerDevice runs PushSharedProfiles split by each device's mode,
+// so a fleet-wide push respects per-device DDM opt-in.
+func pushSharedProfilesPerDevice(devices []types.Device, profiles []types.SharedProfile) error {
+	ddmDevices, legacyDevices := partitionByDDM(devices)
+	var errs []error
+	if len(ddmDevices) > 0 {
+		if _, err := PushSharedProfiles(ddmDevices, profiles, true); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(legacyDevices) > 0 {
+		if _, err := PushSharedProfiles(legacyDevices, profiles, false); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return intErrors.Join(errs...)
+}
+
+// deleteSharedProfilesPerDevice runs DeleteSharedProfiles split by each device's mode.
+func deleteSharedProfilesPerDevice(devices []types.Device, profiles []types.SharedProfile) error {
+	ddmDevices, legacyDevices := partitionByDDM(devices)
+	var errs []error
+	if len(ddmDevices) > 0 {
+		if _, err := DeleteSharedProfiles(ddmDevices, profiles, true); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(legacyDevices) > 0 {
+		if _, err := DeleteSharedProfiles(legacyDevices, profiles, false); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return intErrors.Join(errs...)
+}
+
+// teardownDDMForDevice best-effort removes a device's DDM PROFILE declarations/sets
+// from KMFDDM when the device is demoted back to classic (Applications are not torn)
+func teardownDDMForDevice(device types.Device) {
+	var deviceProfiles []types.DeviceProfile
+	if err := db.DB.Where("device_ud_id = ?", device.UDID).Find(&deviceProfiles).Error; err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: device.UDID, Message: "teardownDDMForDevice: load device profiles: " + err.Error()})
+	} else if len(deviceProfiles) > 0 {
+		if err := DeleteDeviceProfilesViaDDM([]types.Device{device}, deviceProfiles); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, Message: "teardownDDMForDevice: delete device profile declarations: " + err.Error()})
+		}
+	}
+
+	var sharedProfiles []types.SharedProfile
+	if err := db.DB.Find(&sharedProfiles).Error; err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: device.UDID, Message: "teardownDDMForDevice: load shared profiles: " + err.Error()})
+	} else if len(sharedProfiles) > 0 {
+		if err := DeleteSharedProfilesViaDDM([]types.Device{device}, sharedProfiles); err != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, Message: "teardownDDMForDevice: delete shared profile declarations: " + err.Error()})
+		}
+	}
+}
+
+// DDMMigrateHandler (POST /device/{udid}/ddm-migrate) promotes a device to DDM by
+// inserting an opt-in row, then reconciles it so its profiles/apps re-push via DDM.
+func DDMMigrateHandler(w http.ResponseWriter, r *http.Request) {
+	udid := mux.Vars(r)["udid"]
+	device, err := GetDevice(udid)
+	if err != nil {
+		http.Error(w, "device not found", http.StatusNotFound)
+		return
+	}
+
+	optIn := DDMMigrationOptIn{DeviceUDID: udid}
+	if err := db.DB.Where(&optIn).FirstOrCreate(&optIn).Error; err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DDMMigrateHandler: create opt-in: " + err.Error()})
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	InfoLogger(LogHolder{DeviceUDID: udid, DeviceSerial: device.SerialNumber, Message: "DDM migration: device promoted to DDM"})
+
+	// Reconcile now so declarations get created and the device switches protocol
+	if _, err := InstallAllProfiles(device); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DDMMigrateHandler: InstallAllProfiles: " + err.Error()})
+	}
+	// Install applications via DDM declarations
+	if _, err := InstallBootstrapPackages(device); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DDMMigrateHandler: InstallBootstrapPackages: " + err.Error()})
+	}
+
+	writeDDMMigrateStatus(w, udid, true)
+}
+
+// DDMUnmigrateHandler (DELETE /device/{udid}/ddm-migrate) demotes a device back to
+// the classic protocol: removes the opt-in row, tears down its DDM declarations,
+// and reconciles so profiles/apps re-push via InstallProfile
+func DDMUnmigrateHandler(w http.ResponseWriter, r *http.Request) {
+	udid := mux.Vars(r)["udid"]
+	device, err := GetDevice(udid)
+	if err != nil {
+		http.Error(w, "device not found", http.StatusNotFound)
+		return
+	}
+
+	// Tear down DDM state while the device is still considered "DDM", then remove
+	// the opt-in row so subsequent operations use the classic path.
+	teardownDDMForDevice(device)
+
+	if err := db.DB.Where("device_udid = ?", udid).Delete(&DDMMigrationOptIn{}).Error; err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DDMUnmigrateHandler: delete opt-in: " + err.Error()})
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	InfoLogger(LogHolder{DeviceUDID: udid, DeviceSerial: device.SerialNumber, Message: "DDM migration: device demoted to classic InstallProfile"})
+
+	// Reconcile profiles now so they re-push via the classic path. Applications are
+	// intentionally left as-is: anything installed via a DDM declaration stays installed
+	if _, err := InstallAllProfiles(device); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DDMUnmigrateHandler: InstallAllProfiles: " + err.Error()})
+	}
+
+	writeDDMMigrateStatus(w, udid, false)
+}
+
+func writeDDMMigrateStatus(w http.ResponseWriter, udid string, useDDM bool) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]interface{}{
+		"device_udid": udid,
+		"use_ddm":     useDDM,
+	}); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "writeDDMMigrateStatus: " + err.Error()})
+	}
+}

--- a/director/ddm_optin.go
+++ b/director/ddm_optin.go
@@ -1,32 +1,11 @@
 package director
 
-// -----------------------------------------------------------------------------
-// TEMPORARY — MicroMDM -> NanoMDM migration only.
+// Per-device DDM control
 //
-// This whole file (plus the `ddm_migration_optins` table) exists so we can flip
-// individual devices (or cohorts) onto DDM independently of the global USE_DDM /
-// USE_DDM_PACKAGES switches. That lets a migration wave land on NanoMDM in the
-// classic InstallProfile / InstallApplication protocol first, and be promoted to
-// DDM later, per device.
-//
-// A single opt-in row covers BOTH profiles and applications for a device. The two
-// global flags remain independent enable-all master switches (see ddmForDevice /
-// ddmPackagesForDevice below).
-//
-// ============================ CLEANUP CHECKLIST ==============================
-// Once the whole fleet is on DDM and per-device control is no longer needed:
-//   1. Delete this file.
-//   2. Replace every call to ddmForDevice(d)        with utils.UseDDM().
-//      Replace every call to ddmPackagesForDevice(d) with utils.UseDDMPackages().
-//      Replace pushSharedProfilesPerDevice / deleteSharedProfilesPerDevice call
-//        sites with the direct PushSharedProfiles / DeleteSharedProfiles calls
-//        passing utils.UseDDM().
-//      Restore the app functions in install_application.go to branch on
-//        utils.UseDDMPackages() at the top (see the "migration" comments there).
-//   3. Remove &DDMMigrationOptIn{} from db.DB.AutoMigrate(...) in main.go and drop
-//      the two /device/{udid}/ddm-migrate routes.
-//   4. DROP TABLE ddm_migration_optins;
-// =============================================================================
+// mdmdirector can manage profiles and applications via Declarative Device Management
+// (DDM). The global USE_DDM / USE_DDM_PACKAGES flags enable DDM for the entire fleet.
+// This file adds finer-grained control: an opt-in list that enables DDM for individual
+// devices while the global flags remain off.
 
 import (
 	"encoding/json"
@@ -39,22 +18,22 @@ import (
 	"github.com/mdmdirector/mdmdirector/utils"
 )
 
-// DDMMigrationOptIn marks a single device as opted into DDM (for both profiles and
-// applications) during the migration. Presence of a row == opted in.
-type DDMMigrationOptIn struct {
+// DDMOptIn marks a single device as opted into DDM (for both profiles and
+// applications). Presence of a row == opted in.
+type DDMOptIn struct {
 	DeviceUDID string `gorm:"primaryKey" json:"device_udid"`
 }
 
-// TableName pins the table name so the CLEANUP "DROP TABLE" is unambiguous.
-func (DDMMigrationOptIn) TableName() string { return "ddm_migration_optins" }
+// TableName sets an explicit table name for the opt-in list
+func (DDMOptIn) TableName() string { return "ddm_opt_ins" }
 
-// deviceOptedIntoDDM reports whether a single device has been explicitly opted in.
+// deviceOptedIntoDDM reports whether a single device has been explicitly opted in
 func deviceOptedIntoDDM(udid string) bool {
 	if udid == "" {
 		return false
 	}
 	var count int64
-	if err := db.DB.Model(&DDMMigrationOptIn{}).Where("device_udid = ?", udid).Count(&count).Error; err != nil {
+	if err := db.DB.Model(&DDMOptIn{}).Where("device_udid = ?", udid).Count(&count).Error; err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "deviceOptedIntoDDM: " + err.Error()})
 		return false
 	}
@@ -71,7 +50,7 @@ func ddmPackagesForDevice(device types.Device) bool {
 	return utils.UseDDMPackages() || deviceOptedIntoDDM(device.UDID)
 }
 
-// optedInSet loads, in a single query, the opt-in membership for the given devices
+// optedInSet loads the opt-in membership for the given devices
 func optedInSet(devices []types.Device) map[string]bool {
 	set := make(map[string]bool)
 	if len(devices) == 0 {
@@ -81,7 +60,7 @@ func optedInSet(devices []types.Device) map[string]bool {
 	for i := range devices {
 		udids = append(udids, devices[i].UDID)
 	}
-	var optIns []DDMMigrationOptIn
+	var optIns []DDMOptIn
 	if err := db.DB.Where("device_udid IN (?)", udids).Find(&optIns).Error; err != nil {
 		ErrorLogger(LogHolder{Message: "optedInSet: " + err.Error()})
 		return set
@@ -92,7 +71,7 @@ func optedInSet(devices []types.Device) map[string]bool {
 	return set
 }
 
-// partitionByDDM splits devices into the DDM cohort and the classic cohort for PROFILE
+// partitionByDDM splits devices into the DDM cohort and the non-DDM cohort for PROFILE operations
 func partitionByDDM(devices []types.Device) (ddmDevices, legacyDevices []types.Device) {
 	global := utils.UseDDM()
 	set := optedInSet(devices)
@@ -106,7 +85,7 @@ func partitionByDDM(devices []types.Device) (ddmDevices, legacyDevices []types.D
 	return
 }
 
-// partitionByDDMPackages splits devices into the DDM cohort and the classic cohort for APPLICATION
+// partitionByDDMPackages splits devices into the DDM cohort and the non-DDM cohort for APPLICATION operations
 func partitionByDDMPackages(devices []types.Device) (ddmDevices, legacyDevices []types.Device) {
 	global := utils.UseDDMPackages()
 	set := optedInSet(devices)
@@ -121,7 +100,7 @@ func partitionByDDMPackages(devices []types.Device) (ddmDevices, legacyDevices [
 }
 
 // pushSharedProfilesPerDevice runs PushSharedProfiles split by each device's mode,
-// so a fleet-wide push respects per-device DDM opt-in.
+// so a fleet-wide push respects per-device DDM opt-in
 func pushSharedProfilesPerDevice(devices []types.Device, profiles []types.SharedProfile) error {
 	ddmDevices, legacyDevices := partitionByDDM(devices)
 	var errs []error
@@ -138,7 +117,7 @@ func pushSharedProfilesPerDevice(devices []types.Device, profiles []types.Shared
 	return intErrors.Join(errs...)
 }
 
-// deleteSharedProfilesPerDevice runs DeleteSharedProfiles split by each device's mode.
+// deleteSharedProfilesPerDevice runs DeleteSharedProfiles split by each device's mode
 func deleteSharedProfilesPerDevice(devices []types.Device, profiles []types.SharedProfile) error {
 	ddmDevices, legacyDevices := partitionByDDM(devices)
 	var errs []error
@@ -155,8 +134,11 @@ func deleteSharedProfilesPerDevice(devices []types.Device, profiles []types.Shar
 	return intErrors.Join(errs...)
 }
 
-// teardownDDMForDevice best-effort removes a device's DDM PROFILE declarations/sets
-// from KMFDDM when the device is demoted back to classic (Applications are not torn)
+// teardownDDMForDevice removes a device's DDM PROFILE declarations/sets
+// from KMFDDM when DDM is disabled for the device
+//
+// Applications are intentionally left in place: an app already installed via a DDM
+// declaration can stay installed
 func teardownDDMForDevice(device types.Device) {
 	var deviceProfiles []types.DeviceProfile
 	if err := db.DB.Where("device_ud_id = ?", device.UDID).Find(&deviceProfiles).Error; err != nil {
@@ -177,9 +159,9 @@ func teardownDDMForDevice(device types.Device) {
 	}
 }
 
-// DDMMigrateHandler (POST /device/{udid}/ddm-migrate) promotes a device to DDM by
-// inserting an opt-in row, then reconciles it so its profiles/apps re-push via DDM.
-func DDMMigrateHandler(w http.ResponseWriter, r *http.Request) {
+// EnableDeviceDDMHandler (POST /device/{udid}/ddm) opts a device into DDM by inserting
+// an opt-in row, then reconciles it so its profiles and applications install via DDM
+func EnableDeviceDDMHandler(w http.ResponseWriter, r *http.Request) {
 	udid := mux.Vars(r)["udid"]
 	device, err := GetDevice(udid)
 	if err != nil {
@@ -187,31 +169,31 @@ func DDMMigrateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	optIn := DDMMigrationOptIn{DeviceUDID: udid}
+	optIn := DDMOptIn{DeviceUDID: udid}
 	if err := db.DB.Where(&optIn).FirstOrCreate(&optIn).Error; err != nil {
-		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DDMMigrateHandler: create opt-in: " + err.Error()})
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "EnableDeviceDDMHandler: create opt-in: " + err.Error()})
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
-	InfoLogger(LogHolder{DeviceUDID: udid, DeviceSerial: device.SerialNumber, Message: "DDM migration: device promoted to DDM"})
+	InfoLogger(LogHolder{DeviceUDID: udid, DeviceSerial: device.SerialNumber, Message: "DDM enabled for device"})
 
-	// Reconcile now so declarations get created and the device switches protocol
+	// Reconcile now so declarations get created and the device switches to DDM.
 	if _, err := InstallAllProfiles(device); err != nil {
-		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DDMMigrateHandler: InstallAllProfiles: " + err.Error()})
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "EnableDeviceDDMHandler: InstallAllProfiles: " + err.Error()})
 	}
-	// Install applications via DDM declarations
+	// Install applications via DDM declarations.
 	if _, err := InstallBootstrapPackages(device); err != nil {
-		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DDMMigrateHandler: InstallBootstrapPackages: " + err.Error()})
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "EnableDeviceDDMHandler: InstallBootstrapPackages: " + err.Error()})
 	}
 
-	writeDDMMigrateStatus(w, udid, true)
+	writeDeviceDDMStatus(w, udid, true)
 }
 
-// DDMUnmigrateHandler (DELETE /device/{udid}/ddm-migrate) demotes a device back to
-// the classic protocol: removes the opt-in row, tears down its DDM declarations,
-// and reconciles so profiles/apps re-push via InstallProfile
-func DDMUnmigrateHandler(w http.ResponseWriter, r *http.Request) {
+// DisableDeviceDDMHandler (DELETE /device/{udid}/ddm) opts a device out of DDM: tears
+// down its DDM profile declarations, removes the opt-in row, and re-pushes profiles via
+// InstallProfile commands
+func DisableDeviceDDMHandler(w http.ResponseWriter, r *http.Request) {
 	udid := mux.Vars(r)["udid"]
 	device, err := GetDevice(udid)
 	if err != nil {
@@ -219,33 +201,31 @@ func DDMUnmigrateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Tear down DDM state while the device is still considered "DDM", then remove
-	// the opt-in row so subsequent operations use the classic path.
+	// Tear down DDM state while the device is still opted in
 	teardownDDMForDevice(device)
 
-	if err := db.DB.Where("device_udid = ?", udid).Delete(&DDMMigrationOptIn{}).Error; err != nil {
-		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DDMUnmigrateHandler: delete opt-in: " + err.Error()})
+	if err := db.DB.Where("device_udid = ?", udid).Delete(&DDMOptIn{}).Error; err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DisableDeviceDDMHandler: delete opt-in: " + err.Error()})
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
-	InfoLogger(LogHolder{DeviceUDID: udid, DeviceSerial: device.SerialNumber, Message: "DDM migration: device demoted to classic InstallProfile"})
+	InfoLogger(LogHolder{DeviceUDID: udid, DeviceSerial: device.SerialNumber, Message: "DDM disabled for device"})
 
-	// Reconcile profiles now so they re-push via the classic path. Applications are
-	// intentionally left as-is: anything installed via a DDM declaration stays installed
+	// Re-push profiles via InstallProfile commands. Applications are intentionally left as is
 	if _, err := InstallAllProfiles(device); err != nil {
-		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DDMUnmigrateHandler: InstallAllProfiles: " + err.Error()})
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DisableDeviceDDMHandler: InstallAllProfiles: " + err.Error()})
 	}
 
-	writeDDMMigrateStatus(w, udid, false)
+	writeDeviceDDMStatus(w, udid, false)
 }
 
-func writeDDMMigrateStatus(w http.ResponseWriter, udid string, useDDM bool) {
+func writeDeviceDDMStatus(w http.ResponseWriter, udid string, useDDM bool) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]interface{}{
 		"device_udid": udid,
 		"use_ddm":     useDDM,
 	}); err != nil {
-		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "writeDDMMigrateStatus: " + err.Error()})
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "writeDeviceDDMStatus: " + err.Error()})
 	}
 }

--- a/director/ddm_optin.go
+++ b/director/ddm_optin.go
@@ -34,7 +34,7 @@ func deviceOptedIntoDDM(udid string) bool {
 		return false
 	}
 	var count int64
-	if err := db.DB.Model(&DDMOptIn{}).Where("device_udid = ?", udid).Count(&count).Error; err != nil {
+	if err := db.DB.Model(&DDMOptIn{}).Where("device_ud_id = ?", udid).Count(&count).Error; err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "deviceOptedIntoDDM: " + err.Error()})
 		return false
 	}
@@ -62,7 +62,7 @@ func optedInSet(devices []types.Device) map[string]bool {
 		udids = append(udids, devices[i].UDID)
 	}
 	var optIns []DDMOptIn
-	if err := db.DB.Where("device_udid IN (?)", udids).Find(&optIns).Error; err != nil {
+	if err := db.DB.Where("device_ud_id IN (?)", udids).Find(&optIns).Error; err != nil {
 		ErrorLogger(LogHolder{Message: "optedInSet: " + err.Error()})
 		return set
 	}
@@ -219,7 +219,7 @@ func DisableDeviceDDMHandler(w http.ResponseWriter, r *http.Request) {
 		reconcileErrs = append(reconcileErrs, fmt.Errorf("teardownDDMForDevice: %w", err))
 	}
 
-	if err := db.DB.Where("device_udid = ?", udid).Delete(&DDMOptIn{}).Error; err != nil {
+	if err := db.DB.Where("device_ud_id = ?", udid).Delete(&DDMOptIn{}).Error; err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DisableDeviceDDMHandler: delete opt-in: " + err.Error()})
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return

--- a/director/ddm_optin.go
+++ b/director/ddm_optin.go
@@ -10,6 +10,7 @@ package director
 import (
 	"encoding/json"
 	intErrors "errors"
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -71,12 +72,14 @@ func optedInSet(devices []types.Device) map[string]bool {
 	return set
 }
 
-// partitionByDDM splits devices into the DDM cohort and the non-DDM cohort for PROFILE operations
-func partitionByDDM(devices []types.Device) (ddmDevices, legacyDevices []types.Device) {
-	global := utils.UseDDM()
+// partitionByGlobalOrOptIn splits devices into the DDM cohort and the non-DDM cohort.
+func partitionByGlobalOrOptIn(devices []types.Device, global bool) (ddmDevices, legacyDevices []types.Device) {
+	if global {
+		return devices, nil
+	}
 	set := optedInSet(devices)
 	for i := range devices {
-		if global || set[devices[i].UDID] {
+		if set[devices[i].UDID] {
 			ddmDevices = append(ddmDevices, devices[i])
 		} else {
 			legacyDevices = append(legacyDevices, devices[i])
@@ -85,18 +88,14 @@ func partitionByDDM(devices []types.Device) (ddmDevices, legacyDevices []types.D
 	return
 }
 
+// partitionByDDM splits devices into the DDM cohort and the non-DDM cohort for PROFILE operations
+func partitionByDDM(devices []types.Device) (ddmDevices, legacyDevices []types.Device) {
+	return partitionByGlobalOrOptIn(devices, utils.UseDDM())
+}
+
 // partitionByDDMPackages splits devices into the DDM cohort and the non-DDM cohort for APPLICATION operations
 func partitionByDDMPackages(devices []types.Device) (ddmDevices, legacyDevices []types.Device) {
-	global := utils.UseDDMPackages()
-	set := optedInSet(devices)
-	for i := range devices {
-		if global || set[devices[i].UDID] {
-			ddmDevices = append(ddmDevices, devices[i])
-		} else {
-			legacyDevices = append(legacyDevices, devices[i])
-		}
-	}
-	return
+	return partitionByGlobalOrOptIn(devices, utils.UseDDMPackages())
 }
 
 // pushSharedProfilesPerDevice runs PushSharedProfiles split by each device's mode,
@@ -139,24 +138,32 @@ func deleteSharedProfilesPerDevice(devices []types.Device, profiles []types.Shar
 //
 // Applications are intentionally left in place: an app already installed via a DDM
 // declaration can stay installed
-func teardownDDMForDevice(device types.Device) {
+func teardownDDMForDevice(device types.Device) error {
+	var errs []error
+	fail := func(stage string, err error) {
+		ErrorLogger(LogHolder{DeviceUDID: device.UDID, Message: "teardownDDMForDevice: " + stage + ": " + err.Error()})
+		errs = append(errs, fmt.Errorf("%s: %w", stage, err))
+	}
+
 	var deviceProfiles []types.DeviceProfile
 	if err := db.DB.Where("device_ud_id = ?", device.UDID).Find(&deviceProfiles).Error; err != nil {
-		ErrorLogger(LogHolder{DeviceUDID: device.UDID, Message: "teardownDDMForDevice: load device profiles: " + err.Error()})
+		fail("load device profiles", err)
 	} else if len(deviceProfiles) > 0 {
 		if err := DeleteDeviceProfilesViaDDM([]types.Device{device}, deviceProfiles); err != nil {
-			ErrorLogger(LogHolder{DeviceUDID: device.UDID, Message: "teardownDDMForDevice: delete device profile declarations: " + err.Error()})
+			fail("delete device profile declarations", err)
 		}
 	}
 
 	var sharedProfiles []types.SharedProfile
 	if err := db.DB.Find(&sharedProfiles).Error; err != nil {
-		ErrorLogger(LogHolder{DeviceUDID: device.UDID, Message: "teardownDDMForDevice: load shared profiles: " + err.Error()})
+		fail("load shared profiles", err)
 	} else if len(sharedProfiles) > 0 {
 		if err := DeleteSharedProfilesViaDDM([]types.Device{device}, sharedProfiles); err != nil {
-			ErrorLogger(LogHolder{DeviceUDID: device.UDID, Message: "teardownDDMForDevice: delete shared profile declarations: " + err.Error()})
+			fail("delete shared profile declarations", err)
 		}
 	}
+
+	return intErrors.Join(errs...)
 }
 
 // EnableDeviceDDMHandler (POST /device/{udid}/ddm) opts a device into DDM by inserting
@@ -178,16 +185,20 @@ func EnableDeviceDDMHandler(w http.ResponseWriter, r *http.Request) {
 
 	InfoLogger(LogHolder{DeviceUDID: udid, DeviceSerial: device.SerialNumber, Message: "DDM enabled for device"})
 
+	var reconcileErrs []error
+
 	// Reconcile now so declarations get created and the device switches to DDM.
 	if _, err := InstallAllProfiles(device); err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "EnableDeviceDDMHandler: InstallAllProfiles: " + err.Error()})
+		reconcileErrs = append(reconcileErrs, fmt.Errorf("InstallAllProfiles: %w", err))
 	}
 	// Install applications via DDM declarations.
 	if _, err := InstallBootstrapPackages(device); err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "EnableDeviceDDMHandler: InstallBootstrapPackages: " + err.Error()})
+		reconcileErrs = append(reconcileErrs, fmt.Errorf("InstallBootstrapPackages: %w", err))
 	}
 
-	writeDeviceDDMStatus(w, udid, true)
+	writeDeviceDDMStatus(w, udid, true, intErrors.Join(reconcileErrs...))
 }
 
 // DisableDeviceDDMHandler (DELETE /device/{udid}/ddm) opts a device out of DDM: tears
@@ -201,8 +212,12 @@ func DisableDeviceDDMHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var reconcileErrs []error
+
 	// Tear down DDM state while the device is still opted in
-	teardownDDMForDevice(device)
+	if err := teardownDDMForDevice(device); err != nil {
+		reconcileErrs = append(reconcileErrs, fmt.Errorf("teardownDDMForDevice: %w", err))
+	}
 
 	if err := db.DB.Where("device_udid = ?", udid).Delete(&DDMOptIn{}).Error; err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DisableDeviceDDMHandler: delete opt-in: " + err.Error()})
@@ -215,17 +230,44 @@ func DisableDeviceDDMHandler(w http.ResponseWriter, r *http.Request) {
 	// Re-push profiles via InstallProfile commands. Applications are intentionally left as is
 	if _, err := InstallAllProfiles(device); err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "DisableDeviceDDMHandler: InstallAllProfiles: " + err.Error()})
+		reconcileErrs = append(reconcileErrs, fmt.Errorf("InstallAllProfiles: %w", err))
 	}
 
-	writeDeviceDDMStatus(w, udid, false)
+	writeDeviceDDMStatus(w, udid, false, intErrors.Join(reconcileErrs...))
 }
 
-func writeDeviceDDMStatus(w http.ResponseWriter, udid string, useDDM bool) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]interface{}{
+// writeDeviceDDMStatus reports the device's mode along with whether the follow-up
+// reconcile fully succeeded. The mode change itself is already committed, so a failed
+// reconcile is a partial success (207) rather than an error: the opt-in state stands and
+// the device catches up on the next reconcile
+func writeDeviceDDMStatus(w http.ResponseWriter, udid string, useDDM bool, reconcileErr error) {
+	body := map[string]interface{}{
 		"device_udid": udid,
 		"use_ddm":     useDDM,
-	}); err != nil {
+		"reconciled":  reconcileErr == nil,
+	}
+
+	status := http.StatusOK
+	if reconcileErr != nil {
+		status = http.StatusMultiStatus
+		body["reconcile_errors"] = errorMessages(reconcileErr)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
 		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "writeDeviceDDMStatus: " + err.Error()})
 	}
+}
+
+// errorMessages flattens a joined error into one message per underlying failure
+func errorMessages(err error) []string {
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		msgs := make([]string, 0, len(joined.Unwrap()))
+		for _, e := range joined.Unwrap() {
+			msgs = append(msgs, e.Error())
+		}
+		return msgs
+	}
+	return []string{err.Error()}
 }

--- a/director/ddm_optin_test.go
+++ b/director/ddm_optin_test.go
@@ -1,0 +1,386 @@
+package director
+
+import (
+	"encoding/json"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDDMFlags registers the DDM globals and resets them after the test, so a test that
+// flips one can't leak that state into the next
+func setupDDMFlags(t *testing.T, useDDM, useDDMPackages bool) {
+	t.Helper()
+	for _, name := range []string{"use-ddm", "use-ddm-packages"} {
+		if flag.Lookup(name) == nil {
+			flag.Bool(name, false, name)
+		}
+	}
+	// Read by the push paths the handlers reconcile through
+	if flag.Lookup("prometheus") == nil {
+		flag.Bool("prometheus", false, "Enable prometheus metrics")
+	}
+
+	require.NoError(t, flag.Set("use-ddm", boolFlag(useDDM)))
+	require.NoError(t, flag.Set("use-ddm-packages", boolFlag(useDDMPackages)))
+
+	t.Cleanup(func() {
+		_ = flag.Set("use-ddm", "false")
+		_ = flag.Set("use-ddm-packages", "false")
+	})
+}
+
+func boolFlag(v bool) string {
+	if v {
+		return "true"
+	}
+	return "false"
+}
+
+// optInRows builds a ddm_opt_ins result set for the given UDIDs. The column is
+// device_ud_id: gorm derives it from the DeviceUDID field, same as everywhere else
+// in the schema
+func optInRows(udids ...string) *sqlmock.Rows {
+	rows := sqlmock.NewRows([]string{"device_ud_id"})
+	for _, udid := range udids {
+		rows.AddRow(udid)
+	}
+	return rows
+}
+
+func testDevices(udids ...string) []types.Device {
+	devices := make([]types.Device, 0, len(udids))
+	for _, udid := range udids {
+		devices = append(devices, types.Device{UDID: udid, SerialNumber: "SERIAL-" + udid})
+	}
+	return devices
+}
+
+// --- ddmForDevice / ddmPackagesForDevice ---
+
+// The global flag alone decides the answer, so no opt-in lookup should be issued at all.
+// The mock has zero expectations: any query would error, and the count would come back 0
+func TestDDMForDevice_GlobalOn_SkipsOptInQuery(t *testing.T) {
+	setupDDMFlags(t, true, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	assert.True(t, ddmForDevice(types.Device{UDID: "udid-1"}))
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+func TestDDMForDevice_OptIn(t *testing.T) {
+	tests := []struct {
+		name     string
+		optInRow bool
+		expected bool
+	}{
+		{name: "opted in", optInRow: true, expected: true},
+		{name: "not opted in", optInRow: false, expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupDDMFlags(t, false, false)
+			mockSpy, cleanup := setupMockDB(t)
+			defer cleanup()
+
+			count := 0
+			if tc.optInRow {
+				count = 1
+			}
+			mockSpy.ExpectQuery(`SELECT count\(\*\) FROM "ddm_opt_ins" WHERE device_ud_id = \$1`).
+				WithArgs("udid-1").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(count))
+
+			assert.Equal(t, tc.expected, ddmForDevice(types.Device{UDID: "udid-1"}))
+			assert.NoError(t, mockSpy.ExpectationsWereMet())
+		})
+	}
+}
+
+// An empty UDID can't be opted in and must not reach the database
+func TestDDMForDevice_EmptyUDID(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	assert.False(t, ddmForDevice(types.Device{}))
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+func TestDDMPackagesForDevice_GlobalOn_SkipsOptInQuery(t *testing.T) {
+	setupDDMFlags(t, false, true)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	assert.True(t, ddmPackagesForDevice(types.Device{UDID: "udid-1"}))
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// The two globals are independent: USE_DDM covers profiles only, so an application
+// decision still falls through to the opt-in list
+func TestDDMPackagesForDevice_ProfileGlobalDoesNotEnablePackages(t *testing.T) {
+	setupDDMFlags(t, true, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockSpy.ExpectQuery(`SELECT count\(\*\) FROM "ddm_opt_ins" WHERE device_ud_id = \$1`).
+		WithArgs("udid-1").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	assert.False(t, ddmPackagesForDevice(types.Device{UDID: "udid-1"}))
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+func TestDDMPackagesForDevice_OptIn(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockSpy.ExpectQuery(`SELECT count\(\*\) FROM "ddm_opt_ins" WHERE device_ud_id = \$1`).
+		WithArgs("udid-1").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	assert.True(t, ddmPackagesForDevice(types.Device{UDID: "udid-1"}))
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// --- partitioning ---
+
+// The cohort split comes from one batched query, and order within each cohort is preserved
+func TestPartitionByDDM_CohortSplit(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockSpy.ExpectQuery(`SELECT \* FROM "ddm_opt_ins" WHERE device_ud_id IN \(\$1,\$2,\$3\)`).
+		WithArgs("udid-1", "udid-2", "udid-3").
+		WillReturnRows(optInRows("udid-2"))
+
+	ddmDevices, legacyDevices := partitionByDDM(testDevices("udid-1", "udid-2", "udid-3"))
+
+	require.Len(t, ddmDevices, 1)
+	assert.Equal(t, "udid-2", ddmDevices[0].UDID)
+	require.Len(t, legacyDevices, 2)
+	assert.Equal(t, "udid-1", legacyDevices[0].UDID)
+	assert.Equal(t, "udid-3", legacyDevices[1].UDID)
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// No opt-in rows means every device stays on the classic protocol
+func TestPartitionByDDM_NoOptIns(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockSpy.ExpectQuery(`SELECT \* FROM "ddm_opt_ins"`).
+		WillReturnRows(optInRows())
+
+	ddmDevices, legacyDevices := partitionByDDM(testDevices("udid-1", "udid-2"))
+
+	assert.Empty(t, ddmDevices)
+	assert.Len(t, legacyDevices, 2)
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// With the global on every device is on DDM, so the opt-in query is skipped entirely
+func TestPartitionByDDM_GlobalOn_SkipsOptInQuery(t *testing.T) {
+	setupDDMFlags(t, true, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	ddmDevices, legacyDevices := partitionByDDM(testDevices("udid-1", "udid-2"))
+
+	assert.Len(t, ddmDevices, 2)
+	assert.Empty(t, legacyDevices)
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// partitionByDDMPackages reads USE_DDM_PACKAGES, not USE_DDM
+func TestPartitionByDDMPackages_ReadsPackagesGlobal(t *testing.T) {
+	setupDDMFlags(t, false, true)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	ddmDevices, legacyDevices := partitionByDDMPackages(testDevices("udid-1"))
+
+	assert.Len(t, ddmDevices, 1)
+	assert.Empty(t, legacyDevices)
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+func TestPartitionByDDMPackages_CohortSplit(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockSpy.ExpectQuery(`SELECT \* FROM "ddm_opt_ins" WHERE device_ud_id IN \(\$1,\$2\)`).
+		WithArgs("udid-1", "udid-2").
+		WillReturnRows(optInRows("udid-1"))
+
+	ddmDevices, legacyDevices := partitionByDDMPackages(testDevices("udid-1", "udid-2"))
+
+	require.Len(t, ddmDevices, 1)
+	assert.Equal(t, "udid-1", ddmDevices[0].UDID)
+	require.Len(t, legacyDevices, 1)
+	assert.Equal(t, "udid-2", legacyDevices[0].UDID)
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// An empty device list short-circuits: nothing to look up
+func TestPartitionByDDM_NoDevices(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	ddmDevices, legacyDevices := partitionByDDM(nil)
+
+	assert.Empty(t, ddmDevices)
+	assert.Empty(t, legacyDevices)
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// --- handlers ---
+
+// serveDeviceDDM routes a request through a mux router so {udid} is populated
+func serveDeviceDDM(t *testing.T, method, udid string) *httptest.ResponseRecorder {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(method, "/device/"+udid+"/ddm", nil)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/device/{udid}/ddm", EnableDeviceDDMHandler).Methods(http.MethodPost)
+	router.HandleFunc("/device/{udid}/ddm", DisableDeviceDDMHandler).Methods(http.MethodDelete)
+	router.ServeHTTP(rr, req)
+
+	return rr
+}
+
+// expectDeviceNotFound mocks the GetDevice lookup returning no rows
+func expectDeviceNotFound(mockSpy sqlmock.Sqlmock, udid string) {
+	mockSpy.ExpectQuery(`SELECT \* FROM "devices" WHERE ud_id = \$1`).
+		WithArgs(udid).
+		WillReturnRows(sqlmock.NewRows([]string{"ud_id", "serial_number"}))
+}
+
+// decodeDDMStatus reads the handler's JSON body
+func decodeDDMStatus(t *testing.T, rr *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	return body
+}
+
+func TestEnableDeviceDDMHandler_UnknownDevice(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	expectDeviceNotFound(mockSpy, "missing-udid")
+
+	rr := serveDeviceDDM(t, http.MethodPost, "missing-udid")
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+func TestDisableDeviceDDMHandler_UnknownDevice(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	expectDeviceNotFound(mockSpy, "missing-udid")
+
+	rr := serveDeviceDDM(t, http.MethodDelete, "missing-udid")
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// Enabling inserts the opt-in row. The reconcile that follows can't succeed against a
+// mock DB, which is the interesting part: the row still stands and the handler reports
+// the partial failure rather than a 5xx
+func TestEnableDeviceDDMHandler_CreatesOptInRow(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockGetDevice(mockSpy, "udid-1")
+
+	// FirstOrCreate: look for an existing row, then insert
+	mockSpy.ExpectQuery(`SELECT \* FROM "ddm_opt_ins"`).
+		WithArgs("udid-1", "udid-1").
+		WillReturnRows(optInRows())
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`INSERT INTO "ddm_opt_ins"`).
+		WithArgs("udid-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mockSpy.ExpectCommit()
+
+	rr := serveDeviceDDM(t, http.MethodPost, "udid-1")
+
+	body := decodeDDMStatus(t, rr)
+	assert.Equal(t, true, body["use_ddm"])
+	assert.Equal(t, http.StatusMultiStatus, rr.Code)
+	assert.Equal(t, false, body["reconciled"])
+	assert.NotEmpty(t, body["reconcile_errors"])
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// Disabling tears down declarations, then deletes the opt-in row. With no profiles to
+// remove the teardown makes no KMFDDM calls, so it reports no errors
+func TestDisableDeviceDDMHandler_DeletesOptInRow(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockGetDevice(mockSpy, "udid-1")
+
+	// teardownDDMForDevice: no device profiles and no shared profiles to tear down
+	mockSpy.ExpectQuery(`SELECT \* FROM "device_profiles"`).
+		WillReturnRows(sqlmock.NewRows([]string{"device_ud_id"}))
+	mockSpy.ExpectQuery(`SELECT \* FROM "shared_profiles"`).
+		WillReturnRows(sqlmock.NewRows([]string{"payload_identifier"}))
+
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`DELETE FROM "ddm_opt_ins" WHERE device_ud_id = \$1`).
+		WithArgs("udid-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mockSpy.ExpectCommit()
+
+	rr := serveDeviceDDM(t, http.MethodDelete, "udid-1")
+
+	body := decodeDDMStatus(t, rr)
+	assert.Equal(t, false, body["use_ddm"])
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// A failed opt-in write is a real error: the caller must not be told the device is on DDM
+func TestEnableDeviceDDMHandler_OptInWriteFails(t *testing.T) {
+	setupDDMFlags(t, false, false)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockGetDevice(mockSpy, "udid-1")
+
+	mockSpy.ExpectQuery(`SELECT \* FROM "ddm_opt_ins"`).
+		WillReturnRows(optInRows())
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`INSERT INTO "ddm_opt_ins"`).
+		WillReturnError(assert.AnError)
+	mockSpy.ExpectRollback()
+
+	rr := serveDeviceDDM(t, http.MethodPost, "udid-1")
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "use_ddm")
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}

--- a/director/install_application.go
+++ b/director/install_application.go
@@ -145,7 +145,7 @@ func SaveInstallApplications(devices []types.Device, payload types.InstallApplic
 }
 
 func PushInstallApplication(devices []types.Device, installApplication types.DeviceInstallApplication) ([]types.Command, error) {
-	// MIGRATION: split by per-device DDM opt-in
+	// DDM-enabled devices install via declarations; the rest via InstallApplication.
 	ddmDevices, legacyDevices := partitionByDDMPackages(devices)
 	if len(ddmDevices) > 0 {
 		if err := PushApplicationsViaDDM(ddmDevices, installApplication.ManifestURL); err != nil {
@@ -206,7 +206,7 @@ func SaveSharedInstallApplications(payload types.InstallApplicationPayload) erro
 }
 
 func PushSharedInstallApplication(devices []types.Device, installSharedApplication types.SharedInstallApplication) ([]types.Command, error) {
-	// MIGRATION: split by per-device DDM opt-in
+	// DDM-enabled devices install via declarations; the rest via InstallApplication.
 	ddmDevices, legacyDevices := partitionByDDMPackages(devices)
 	if len(ddmDevices) > 0 {
 		if err := PushSharedApplicationsViaDDM(ddmDevices, installSharedApplication.ManifestURL); err != nil {
@@ -243,7 +243,6 @@ func PushSharedInstallApplication(devices []types.Device, installSharedApplicati
 }
 
 func InstallBootstrapPackages(device types.Device) ([]types.Command, error) {
-	// MIGRATION: per-device DDM opt-in
 	if ddmPackagesForDevice(device) {
 		return nil, installBootstrapPackagesViaDDM(device)
 	}
@@ -354,7 +353,7 @@ func DeleteInstallApplicationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// MIGRATION: tear down declarations only for the per-device DDM cohort
+	// Tear down declarations only for DDM-enabled devices.
 	devices, err := GetAllDevices()
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})

--- a/director/install_application.go
+++ b/director/install_application.go
@@ -2,6 +2,7 @@ package director
 
 import (
 	"encoding/json"
+	intErrors "errors"
 	"net/http"
 
 	"github.com/mdmdirector/mdmdirector/db"
@@ -147,9 +148,10 @@ func SaveInstallApplications(devices []types.Device, payload types.InstallApplic
 func PushInstallApplication(devices []types.Device, installApplication types.DeviceInstallApplication) ([]types.Command, error) {
 	// DDM-enabled devices install via declarations; the rest via InstallApplication.
 	ddmDevices, legacyDevices := partitionByDDMPackages(devices)
+	var errs []error
 	if len(ddmDevices) > 0 {
 		if err := PushApplicationsViaDDM(ddmDevices, installApplication.ManifestURL); err != nil {
-			return nil, err
+			errs = append(errs, err)
 		}
 	}
 
@@ -185,7 +187,7 @@ func PushInstallApplication(devices []types.Device, installApplication types.Dev
 		}
 
 	}
-	return sentCommands, nil
+	return sentCommands, intErrors.Join(errs...)
 }
 
 func SaveSharedInstallApplications(payload types.InstallApplicationPayload) error {
@@ -208,9 +210,10 @@ func SaveSharedInstallApplications(payload types.InstallApplicationPayload) erro
 func PushSharedInstallApplication(devices []types.Device, installSharedApplication types.SharedInstallApplication) ([]types.Command, error) {
 	// DDM-enabled devices install via declarations; the rest via InstallApplication.
 	ddmDevices, legacyDevices := partitionByDDMPackages(devices)
+	var errs []error
 	if len(ddmDevices) > 0 {
 		if err := PushSharedApplicationsViaDDM(ddmDevices, installSharedApplication.ManifestURL); err != nil {
-			return nil, err
+			errs = append(errs, err)
 		}
 	}
 
@@ -234,12 +237,13 @@ func PushSharedInstallApplication(devices []types.Device, installSharedApplicati
 			metrics.ApplicationOperations("shared", "pushed", metrics.ResultFromError(err)).Inc()
 		}
 		if err != nil {
-			return sentCommands, errors.Wrap(err, "Push Shared Install Application")
+			errs = append(errs, errors.Wrap(err, "Push Shared Install Application"))
+			return sentCommands, intErrors.Join(errs...)
 		}
 		sentCommands = append(sentCommands, command)
 
 	}
-	return sentCommands, nil
+	return sentCommands, intErrors.Join(errs...)
 }
 
 func InstallBootstrapPackages(device types.Device) ([]types.Command, error) {

--- a/director/install_application.go
+++ b/director/install_application.go
@@ -145,13 +145,17 @@ func SaveInstallApplications(devices []types.Device, payload types.InstallApplic
 }
 
 func PushInstallApplication(devices []types.Device, installApplication types.DeviceInstallApplication) ([]types.Command, error) {
-	if utils.UseDDMPackages() {
-		return nil, PushApplicationsViaDDM(devices, installApplication.ManifestURL)
+	// MIGRATION: split by per-device DDM opt-in
+	ddmDevices, legacyDevices := partitionByDDMPackages(devices)
+	if len(ddmDevices) > 0 {
+		if err := PushApplicationsViaDDM(ddmDevices, installApplication.ManifestURL); err != nil {
+			return nil, err
+		}
 	}
 
 	var sentCommands []types.Command
-	for i := range devices {
-		device := devices[i]
+	for i := range legacyDevices {
+		device := legacyDevices[i]
 		inQueue, err := InstallAppInQueue(device, installApplication.ManifestURL)
 		if err != nil {
 			// Shit went wrong for this device, but logging here feels wrong
@@ -202,13 +206,17 @@ func SaveSharedInstallApplications(payload types.InstallApplicationPayload) erro
 }
 
 func PushSharedInstallApplication(devices []types.Device, installSharedApplication types.SharedInstallApplication) ([]types.Command, error) {
-	if utils.UseDDMPackages() {
-		return nil, PushSharedApplicationsViaDDM(devices, installSharedApplication.ManifestURL)
+	// MIGRATION: split by per-device DDM opt-in
+	ddmDevices, legacyDevices := partitionByDDMPackages(devices)
+	if len(ddmDevices) > 0 {
+		if err := PushSharedApplicationsViaDDM(ddmDevices, installSharedApplication.ManifestURL); err != nil {
+			return nil, err
+		}
 	}
 
 	var sentCommands []types.Command
-	for i := range devices {
-		device := devices[i]
+	for i := range legacyDevices {
+		device := legacyDevices[i]
 		log.Infof("Pushing InstallApplication to %v", device.UDID)
 		inQueue, _ := InstallAppInQueue(device, installSharedApplication.ManifestURL)
 		if inQueue {
@@ -235,7 +243,8 @@ func PushSharedInstallApplication(devices []types.Device, installSharedApplicati
 }
 
 func InstallBootstrapPackages(device types.Device) ([]types.Command, error) {
-	if utils.UseDDMPackages() {
+	// MIGRATION: per-device DDM opt-in
+	if ddmPackagesForDevice(device) {
 		return nil, installBootstrapPackagesViaDDM(device)
 	}
 
@@ -345,7 +354,16 @@ func DeleteInstallApplicationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !utils.UseDDMPackages() {
+	// MIGRATION: tear down declarations only for the per-device DDM cohort
+	devices, err := GetAllDevices()
+	if err != nil {
+		ErrorLogger(LogHolder{Message: err.Error()})
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	ddmDevices, _ := partitionByDDMPackages(devices)
+	if len(ddmDevices) == 0 {
 		return
 	}
 
@@ -356,15 +374,8 @@ func DeleteInstallApplicationHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	devices, err := GetAllDevices()
-	if err != nil {
-		ErrorLogger(LogHolder{Message: err.Error()})
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-
 	for _, app := range sharedApps {
-		for _, device := range devices {
+		for _, device := range ddmDevices {
 			if err := DeleteSharedInstallApplicationViaDDM(client, device.UDID, app); err != nil {
 				ErrorLogger(LogHolder{Message: err.Error(), DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber})
 			}

--- a/director/profile.go
+++ b/director/profile.go
@@ -188,7 +188,7 @@ func PostProfileHandler(w http.ResponseWriter, r *http.Request) {
 				}
 
 				if out.PushNow {
-					_, err = PushSharedProfiles(devices, sharedProfiles, utils.UseDDM())
+					err = pushSharedProfilesPerDevice(devices, sharedProfiles)
 					if err != nil {
 						ErrorLogger(LogHolder{Message: err.Error()})
 					}
@@ -228,7 +228,7 @@ func PostProfileHandler(w http.ResponseWriter, r *http.Request) {
 				}
 
 				if out.PushNow {
-					_, err = PushSharedProfiles(devices, sharedProfiles, utils.UseDDM())
+					err = pushSharedProfilesPerDevice(devices, sharedProfiles)
 					if err != nil {
 						ErrorLogger(LogHolder{Message: err.Error()})
 					}
@@ -302,7 +302,7 @@ func ProcessDeviceProfiles(
 					if err := SaveProfiles([]types.Device{device}, []types.DeviceProfile{profile}); err != nil {
 						return metadata, errors.Wrap(err, "Save profile before push")
 					}
-					_, err = PushProfiles(devices, []types.DeviceProfile{profile}, utils.UseDDM())
+					_, err = PushProfiles(devices, []types.DeviceProfile{profile}, ddmForDevice(device))
 					if err != nil {
 						ErrorLogger(LogHolder{Message: err.Error()})
 					}
@@ -340,7 +340,7 @@ func ProcessDeviceProfiles(
 
 			if pushNow && profilePresent {
 				deletedProfile := []types.DeviceProfile{profile}
-				_, err := DeleteDeviceProfiles(devices, deletedProfile, utils.UseDDM())
+				_, err := DeleteDeviceProfiles(devices, deletedProfile, ddmForDevice(device))
 				if err != nil {
 					return metadata, errors.Wrap(err, "Delete device profiles")
 				}
@@ -472,7 +472,7 @@ func DisableSharedProfiles(payload types.DeleteProfilePayload) error {
 			)
 		}
 	}
-	_, err = DeleteSharedProfiles(devices, sharedProfiles, utils.UseDDM())
+	err = deleteSharedProfilesPerDevice(devices, sharedProfiles)
 	if err != nil {
 		return errors.Wrap(err, "Profiles::DisableSharedProfiles: DeleteSharedProfiles")
 	}
@@ -1103,22 +1103,22 @@ func VerifyMDMProfiles(profileListData types.ProfileListData, device types.Devic
 	}
 
 	devices = append(devices, device)
-	_, err = PushProfiles(devices, profilesToInstall, utils.UseDDM())
+	_, err = PushProfiles(devices, profilesToInstall, ddmForDevice(device))
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
 
-	_, err = PushSharedProfiles(devices, sharedProfilesToInstall, utils.UseDDM())
+	_, err = PushSharedProfiles(devices, sharedProfilesToInstall, ddmForDevice(device))
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
 
-	_, err = DeleteDeviceProfiles(devices, profilesToRemove, utils.UseDDM())
+	_, err = DeleteDeviceProfiles(devices, profilesToRemove, ddmForDevice(device))
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
 
-	_, err = DeleteSharedProfiles(devices, sharedProfilesToRemove, utils.UseDDM())
+	_, err = DeleteSharedProfiles(devices, sharedProfilesToRemove, ddmForDevice(device))
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
@@ -1395,7 +1395,7 @@ func InstallAllProfiles(device types.Device) ([]types.Command, error) {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
 	log.Debugf("Pushing Profiles %v", device.UDID)
-	commands, err := PushProfiles(devices, profiles, utils.UseDDM())
+	commands, err := PushProfiles(devices, profiles, ddmForDevice(device))
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	} else {
@@ -1424,7 +1424,7 @@ func InstallAllProfiles(device types.Device) ([]types.Command, error) {
 	}
 
 	log.Debugf("Pushing Shared Profiles %v", device.UDID)
-	commands, err = PushSharedProfiles(devices, unskippedSharedProfiles, utils.UseDDM())
+	commands, err = PushSharedProfiles(devices, unskippedSharedProfiles, ddmForDevice(device))
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	} else {

--- a/director/profile.go
+++ b/director/profile.go
@@ -277,6 +277,8 @@ func ProcessDeviceProfiles(
 	var profileMetadataList []types.ProfileMetadata
 	var profilesToSave []types.DeviceProfile
 
+	useDDM := ddmForDevice(device)
+
 	// metadata.Device = device
 	for i := range profiles {
 		var profileMetadata types.ProfileMetadata
@@ -302,7 +304,7 @@ func ProcessDeviceProfiles(
 					if err := SaveProfiles([]types.Device{device}, []types.DeviceProfile{profile}); err != nil {
 						return metadata, errors.Wrap(err, "Save profile before push")
 					}
-					_, err = PushProfiles(devices, []types.DeviceProfile{profile}, ddmForDevice(device))
+					_, err = PushProfiles(devices, []types.DeviceProfile{profile}, useDDM)
 					if err != nil {
 						ErrorLogger(LogHolder{Message: err.Error()})
 					}
@@ -340,7 +342,7 @@ func ProcessDeviceProfiles(
 
 			if pushNow && profilePresent {
 				deletedProfile := []types.DeviceProfile{profile}
-				_, err := DeleteDeviceProfiles(devices, deletedProfile, ddmForDevice(device))
+				_, err := DeleteDeviceProfiles(devices, deletedProfile, useDDM)
 				if err != nil {
 					return metadata, errors.Wrap(err, "Delete device profiles")
 				}
@@ -1103,22 +1105,24 @@ func VerifyMDMProfiles(profileListData types.ProfileListData, device types.Devic
 	}
 
 	devices = append(devices, device)
-	_, err = PushProfiles(devices, profilesToInstall, ddmForDevice(device))
+	useDDM := ddmForDevice(device)
+
+	_, err = PushProfiles(devices, profilesToInstall, useDDM)
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
 
-	_, err = PushSharedProfiles(devices, sharedProfilesToInstall, ddmForDevice(device))
+	_, err = PushSharedProfiles(devices, sharedProfilesToInstall, useDDM)
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
 
-	_, err = DeleteDeviceProfiles(devices, profilesToRemove, ddmForDevice(device))
+	_, err = DeleteDeviceProfiles(devices, profilesToRemove, useDDM)
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
 
-	_, err = DeleteSharedProfiles(devices, sharedProfilesToRemove, ddmForDevice(device))
+	_, err = DeleteSharedProfiles(devices, sharedProfilesToRemove, useDDM)
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
@@ -1385,6 +1389,7 @@ func InstallAllProfiles(device types.Device) ([]types.Command, error) {
 	var pushedCommands []types.Command
 
 	devices = append(devices, device)
+	useDDM := ddmForDevice(device)
 
 	// Get the profiles that should be installed on the device
 	err := db.DB.Model(&profile).
@@ -1395,7 +1400,7 @@ func InstallAllProfiles(device types.Device) ([]types.Command, error) {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	}
 	log.Debugf("Pushing Profiles %v", device.UDID)
-	commands, err := PushProfiles(devices, profiles, ddmForDevice(device))
+	commands, err := PushProfiles(devices, profiles, useDDM)
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	} else {
@@ -1424,7 +1429,7 @@ func InstallAllProfiles(device types.Device) ([]types.Command, error) {
 	}
 
 	log.Debugf("Pushing Shared Profiles %v", device.UDID)
-	commands, err = PushSharedProfiles(devices, unskippedSharedProfiles, ddmForDevice(device))
+	commands, err = PushSharedProfiles(devices, unskippedSharedProfiles, useDDM)
 	if err != nil {
 		ErrorLogger(LogHolder{Message: err.Error()})
 	} else {

--- a/main.go
+++ b/main.go
@@ -529,6 +529,9 @@ func main() {
 	r.HandleFunc("/command", utils.BasicAuth(director.GetAllCommands)).Methods("GET")
 	r.HandleFunc("/health", director.HealthCheck).Methods("GET")
 	r.HandleFunc("/profiledownload/{udid}/{profileIdentifier}", director.ProfileDownloadHandler).Methods("GET")
+	// TEMPORARY (MicroMDM->NanoMDM migration): per-device DDM opt-in management.
+	r.HandleFunc("/device/{udid}/ddm-migrate", utils.BasicAuth(director.DDMMigrateHandler)).Methods("POST")
+	r.HandleFunc("/device/{udid}/ddm-migrate", utils.BasicAuth(director.DDMUnmigrateHandler)).Methods("DELETE")
 
 	director.InfoLogger(director.LogHolder{Message: "Connecting to database"})
 	if err := db.Open(); err != nil {
@@ -557,6 +560,8 @@ func main() {
 		&types.Certificate{},
 		&types.ProfileList{},
 		&types.UnlockPin{},
+		// TEMPORARY (MicroMDM->NanoMDM migration): per-device DDM opt-in list.
+		&director.DDMMigrationOptIn{},
 	)
 	if err != nil {
 		director.ErrorLogger(director.LogHolder{Message: err.Error()})

--- a/main.go
+++ b/main.go
@@ -529,9 +529,9 @@ func main() {
 	r.HandleFunc("/command", utils.BasicAuth(director.GetAllCommands)).Methods("GET")
 	r.HandleFunc("/health", director.HealthCheck).Methods("GET")
 	r.HandleFunc("/profiledownload/{udid}/{profileIdentifier}", director.ProfileDownloadHandler).Methods("GET")
-	// TEMPORARY (MicroMDM->NanoMDM migration): per-device DDM opt-in management.
-	r.HandleFunc("/device/{udid}/ddm-migrate", utils.BasicAuth(director.DDMMigrateHandler)).Methods("POST")
-	r.HandleFunc("/device/{udid}/ddm-migrate", utils.BasicAuth(director.DDMUnmigrateHandler)).Methods("DELETE")
+	// Per-device DDM opt-in management.
+	r.HandleFunc("/device/{udid}/ddm", utils.BasicAuth(director.EnableDeviceDDMHandler)).Methods("POST")
+	r.HandleFunc("/device/{udid}/ddm", utils.BasicAuth(director.DisableDeviceDDMHandler)).Methods("DELETE")
 
 	director.InfoLogger(director.LogHolder{Message: "Connecting to database"})
 	if err := db.Open(); err != nil {
@@ -560,8 +560,7 @@ func main() {
 		&types.Certificate{},
 		&types.ProfileList{},
 		&types.UnlockPin{},
-		// TEMPORARY (MicroMDM->NanoMDM migration): per-device DDM opt-in list.
-		&director.DDMMigrationOptIn{},
+		&director.DDMOptIn{},
 	)
 	if err != nil {
 		director.ErrorLogger(director.LogHolder{Message: err.Error()})


### PR DESCRIPTION
 ## What & why

  DDM is currently an all-or-nothing switch: flipping `USE_DDM` / `USE_DDM_PACKAGES`
  forces *every* device onto Declarative Device Management at once. That's a hard sell for
  anyone with a large fleet — there's no way to try DDM on a handful of devices, confirm
  profiles and apps land correctly, and expand from there.

This PR adds a **per-device DDM opt-in** layered on top of the existing global flags,
so a fleet can adopt DDM device by device. A device is on DDM if the global flag is on
**or** it has an opt-in row — so the globals keep working exactly as they do today as
enable-all master switches, and nothing about their behavior changes when they're set.

A single opt-in row covers **both profiles and applications** for a device.

This is what makes a staged MicroMDM→NanoMDM migration practical: a wave can land on
NanoMDM using the classic InstallProfile/InstallApplication protocol, then be promoted
to DDM once it's verified — per device, without a redeploy.

## How it works

- New table `ddm_opt_ins` (one row per opted-in device, keyed on `device_udid`).
- The per-device logic lives in `director/ddm_optin.go`:
  - `ddmForDevice(device)` / `ddmPackagesForDevice(device)` — the per-device decision
    (global flag OR opt-in row), used by single-device paths.
  - `partitionByDDM` / `partitionByDDMPackages` — split a device slice into DDM vs
    classic cohorts in a single batched query, for fleet-wide fan-out sites. Both
    delegate to `partitionByGlobalOrOptIn`, which skips the opt-in query entirely when
    the relevant global flag is on, so an all-DDM fleet pays nothing for this feature.
  - `pushSharedProfilesPerDevice` / `deleteSharedProfilesPerDevice` — run a fleet-wide
    shared-profile operation across both cohorts, aggregating errors so a failure in one
    protocol doesn't strand the devices on the other.
- Call sites in `director/profile.go` and `director/install_application.go` decide per
  device instead of reading the global directly. Single-device paths resolve the mode
  once per request; multi-device fan-outs partition and run each cohort in its own
  protocol.

## Admin API

- `POST /device/{udid}/ddm` — **enable** DDM for a device: inserts the opt-in row, then
  reconciles the device so profiles and applications (re)install via DDM declarations.
- `DELETE /device/{udid}/ddm` — **disable** DDM for a device: tears down the device's
  DDM **profile** declarations, removes the opt-in row, and re-pushes profiles via
  classic InstallProfile.

Both are behind the existing basic auth, and both return the device's resulting mode
plus whether the follow-up reconcile fully succeeded:

```json
{"device_udid": "...", "use_ddm": true, "reconciled": true}
```

The mode change is committed before the reconcile runs, so a reconcile failure is a
partial success rather than an error: the response is `207 Multi-Status` with
`reconciled: false` and a `reconcile_errors` list, the opt-in state stands, and the
device catches up on its next reconcile. Callers that only need the mode can read
`use_ddm` and ignore the rest.

## Application behavior (intentional)

- **On enable:** applications are installed via DDM declarations (`InstallBootstrapPackages`).
- **On disable:** applications are **left as-is** — anything already installed via a DDM
  declaration stays installed. Apps are not torn down or re-pushed. (Edge case: changing
  an app's manifest while the device is in classic mode won't reach it until DDM is
  re-enabled for that device.)

## Compatibility

- Existing deployments are unaffected: with no opt-in rows and the globals untouched,
  every code path resolves to exactly the behavior it has today.
- The only schema change is the new `ddm_opt_ins` table. Nothing touches `types.Device`
  or adds columns to existing tables.
- Reverting a single device is a `DELETE` call — no redeploy, and it returns to classic
  on the next reconcile.
Tip: Use /btw to ask a quick side question without interrupting Claude's current work