### PR TITLE
[MDMv2] Health endpoint verify database connectivity

### DIFF
--- a/director/healthcheck.go
+++ b/director/healthcheck.go
@@ -1,15 +1,57 @@
 package director
 
-import "net/http"
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
 
-// todo
-// verify database is accessible
-// verify we can connect to micromdm
+	"github.com/mdmdirector/mdmdirector/db"
+)
+
+const healthCheckTimeout = 5 * time.Second
+
+// pinger is satisfied by the *sql.DB pool backing gorm.
+type pinger interface {
+	PingContext(ctx context.Context) error
+}
+
+// resolvePinger hands back the pool that real traffic uses
+var resolvePinger = func() (pinger, error) {
+	if db.DB == nil {
+		return nil, errors.New("database is not open")
+	}
+	return db.DB.DB()
+}
+
+// HealthCheck reports whether mdmdirector can reach its database. It pings the
+// connection pool directly instead of issuing a query
 func HealthCheck(w http.ResponseWriter, r *http.Request) {
-	output := []byte("{\"status\":\"UP\"}")
-	_, err := w.Write(output)
-	if err != nil {
-		http.Error(w, "couldn't report status", http.StatusInternalServerError)
+	ctx, cancel := context.WithTimeout(r.Context(), healthCheckTimeout)
+	defer cancel()
+
+	if err := pingDB(ctx); err != nil {
+		ErrorLogger(LogHolder{Message: "health check failed: database unavailable: " + err.Error()})
+		writeHealth(w, http.StatusServiceUnavailable, `{"status":"DOWN"}`)
 		return
+	}
+
+	writeHealth(w, http.StatusOK, `{"status":"UP"}`)
+}
+
+func pingDB(ctx context.Context) error {
+	p, err := resolvePinger()
+	if err != nil {
+		return err
+	}
+	return p.PingContext(ctx)
+}
+
+func writeHealth(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	// The status is already sent, so a failed write can only be logged.
+	if _, err := w.Write([]byte(body)); err != nil {
+		ErrorLogger(LogHolder{Message: "couldn't report status: " + err.Error()})
 	}
 }

--- a/director/healthcheck_test.go
+++ b/director/healthcheck_test.go
@@ -1,0 +1,76 @@
+package director
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mdmdirector/mdmdirector/db"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakePinger struct {
+	err    error
+	called bool
+}
+
+func (p *fakePinger) PingContext(_ context.Context) error {
+	p.called = true
+	return p.err
+}
+
+// withPinger swaps the package-level resolver for the duration of a test.
+func withPinger(t *testing.T, p pinger, err error) {
+	t.Helper()
+	original := resolvePinger
+	resolvePinger = func() (pinger, error) { return p, err }
+	t.Cleanup(func() { resolvePinger = original })
+}
+
+func TestHealthCheckReachableDB(t *testing.T) {
+	fake := &fakePinger{}
+	withPinger(t, fake, nil)
+	rec := httptest.NewRecorder()
+
+	HealthCheck(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `{"status":"UP"}`, rec.Body.String())
+	assert.True(t, fake.called)
+}
+
+func TestHealthCheckUnreachableDB(t *testing.T) {
+	withPinger(t, &fakePinger{err: errors.New("connection refused")}, nil)
+	rec := httptest.NewRecorder()
+
+	HealthCheck(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.JSONEq(t, `{"status":"DOWN"}`, rec.Body.String())
+}
+
+// /health is registered before db.Open() runs, so an unresolvable pool must
+// report DOWN rather than panic on a nil db.DB.
+func TestHealthCheckDBNotOpen(t *testing.T) {
+	withPinger(t, nil, errors.New("database is not open"))
+	rec := httptest.NewRecorder()
+
+	HealthCheck(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.JSONEq(t, `{"status":"DOWN"}`, rec.Body.String())
+}
+
+// The default resolver must not dereference a nil db.DB. db.DB is set
+// explicitly because other tests in this package assign it globally.
+func TestDefaultResolvePingerWithoutOpenDB(t *testing.T) {
+	original := db.DB
+	db.DB = nil
+	t.Cleanup(func() { db.DB = original })
+
+	_, err := resolvePinger()
+
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## What

`/health` already existed but was a stub that always returned `200 {"status":"UP"}`, with a TODO in the code stating what was missing:

```go
// todo
// verify database is accessible
// verify we can connect to micromdm
```

It would report healthy with a completely dead database, so it was unusable as a readiness signal. This wires it to a real check.

`/health` now pings the Postgres connection pool directly (no query) with a 5s timeout:

- reachable → `200 {"status":"UP"}`
- unreachable, or DB not open → `503 {"status":"DOWN"}` and an error log

The `{"status":"UP"}` body is preserved on success in case anything already parses it.