### PR TITLE
feat: single-flight control plane via shared Redis lock

### DIFF
--- a/director/controlplane.go
+++ b/director/controlplane.go
@@ -1,0 +1,65 @@
+package director
+
+import (
+	"context"
+	"time"
+
+	"github.com/bsm/redislock"
+	"github.com/pkg/errors"
+)
+
+const (
+	// controlPlaneLockKey is the shared Redis key guarding the periodic control-plane
+	// scan (device push scheduling + cleanup). Only the pod holding it runs the scan on
+	// a given tick; every other pod skips. This is what makes the control plane
+	// single-flight across replicas without any leader election.
+	controlPlaneLockKey = "mdmdirector:control-plane"
+
+	// controlPlaneLockTTL is how long the lock is held before it must be refreshed. A
+	// scan can run for many minutes (pushAll paces itself with ~1m sleeps per chunk), so
+	// a background refresher keeps the lock alive while the holder works. If the holder
+	// dies mid-scan, the lock expires within this TTL and another pod takes over on its
+	// next tick -- automatic failover, no SPOF.
+	controlPlaneLockTTL = 30 * time.Second
+)
+
+// withControlPlaneLock runs fn only if this process can acquire the fleet-wide
+// control-plane lock. If another pod already holds it, fn is skipped and (false, nil)
+// is returned. While fn runs, a goroutine refreshes the lock periodically so a long
+// scan does not lose it; the lock is released when fn returns. Returns whether fn ran
+// and any error from acquiring the lock or from fn itself.
+func withControlPlaneLock(ctx context.Context, rc redislock.RedisClient, fn func(context.Context) error) (bool, error) {
+	locker := redislock.New(rc)
+	lock, err := locker.Obtain(ctx, controlPlaneLockKey, controlPlaneLockTTL, nil)
+	if errors.Is(err, redislock.ErrNotObtained) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.Wrap(err, "withControlPlaneLock: obtain")
+	}
+	defer func() {
+		if rerr := lock.Release(context.Background()); rerr != nil && !errors.Is(rerr, redislock.ErrLockNotHeld) {
+			ErrorLogger(LogHolder{Message: "control-plane lock release: " + rerr.Error()})
+		}
+	}()
+
+	// Keep the lock alive for the duration of fn.
+	refreshCtx, stopRefresh := context.WithCancel(ctx)
+	defer stopRefresh()
+	go func() {
+		ticker := time.NewTicker(controlPlaneLockTTL / 3)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-refreshCtx.Done():
+				return
+			case <-ticker.C:
+				if rerr := lock.Refresh(refreshCtx, controlPlaneLockTTL, nil); rerr != nil {
+					DebugLogger(LogHolder{Message: "control-plane lock refresh: " + rerr.Error()})
+				}
+			}
+		}
+	}()
+
+	return true, fn(ctx)
+}

--- a/director/controlplane_test.go
+++ b/director/controlplane_test.go
@@ -1,0 +1,83 @@
+package director
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/bsm/redislock"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRedis(t *testing.T) *redis.Client {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+	return redis.NewClient(&redis.Options{Addr: mr.Addr()})
+}
+
+// TestWithControlPlaneLockSkipsWhenHeld verifies that when one replica already holds the
+// control-plane lock, a second replica's attempt is skipped (fn does not run). This is
+// the core single-flight guarantee that makes the control plane safe under N replicas.
+func TestWithControlPlaneLockSkipsWhenHeld(t *testing.T) {
+	rc := newTestRedis(t)
+	ctx := context.Background()
+
+	// Replica A grabs and holds the lock.
+	held, err := redislock.New(rc).Obtain(ctx, controlPlaneLockKey, controlPlaneLockTTL, nil)
+	require.NoError(t, err)
+	defer func() { _ = held.Release(ctx) }()
+
+	// Replica B attempts while A holds it: fn must not run.
+	ran, err := withControlPlaneLock(ctx, rc, func(context.Context) error {
+		t.Fatal("control-plane body ran while another replica held the lock")
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.False(t, ran)
+}
+
+// TestWithControlPlaneLockFailover verifies that once the current holder releases the
+// lock (e.g. it finished, or died and the TTL expired), another replica can acquire it
+// and run on the next tick. No fixed owner, automatic failover, no leader election.
+func TestWithControlPlaneLockFailover(t *testing.T) {
+	rc := newTestRedis(t)
+	ctx := context.Background()
+
+	held, err := redislock.New(rc).Obtain(ctx, controlPlaneLockKey, controlPlaneLockTTL, nil)
+	require.NoError(t, err)
+
+	// While held, another attempt is skipped.
+	ran, err := withControlPlaneLock(ctx, rc, func(context.Context) error { return nil })
+	require.NoError(t, err)
+	require.False(t, ran)
+
+	// Holder goes away.
+	require.NoError(t, held.Release(ctx))
+
+	// Now a replica acquires the lock and runs the body.
+	var bodyRan bool
+	ok, err := withControlPlaneLock(ctx, rc, func(context.Context) error {
+		bodyRan = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.True(t, bodyRan)
+}
+
+// TestWithControlPlaneLockReleasesAfterRun verifies the lock is released when fn returns,
+// so the very next scan (this replica or another) can acquire it again.
+func TestWithControlPlaneLockReleasesAfterRun(t *testing.T) {
+	rc := newTestRedis(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		ran, err := withControlPlaneLock(ctx, rc, func(context.Context) error { return nil })
+		require.NoError(t, err)
+		assert.True(t, ran, "iteration %d should acquire the lock after the previous run released it", i)
+	}
+}

--- a/director/schedule_push.go
+++ b/director/schedule_push.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"path"
 	"strconv"
-	"sync"
 	"time"
 
+	"github.com/bsm/redislock"
 	"github.com/mdmdirector/mdmdirector/db"
 	"github.com/mdmdirector/mdmdirector/director/metrics"
 	"github.com/mdmdirector/mdmdirector/mdm"
@@ -35,7 +35,16 @@ var pushTask = taskq.RegisterTask(&taskq.TaskOptions{
 	},
 })
 
-func ScheduledCheckin(ctx context.Context, pushQueue taskq.Queue, onceIn time.Duration) {
+// ScheduledCheckin runs the control plane: a periodic, fleet-wide scan that enqueues
+// due devices for push and performs DB cleanup. It runs once immediately and then every
+// `interval`. Each run is gated by a shared Redis lock (rc), so at most one replica runs
+// the scan per tick; the rest skip. This is what lets mdmdirector scale horizontally --
+// the data plane (the taskq consumer) scales with pod count while this control plane
+// stays single-flight with automatic failover, and no leader election.
+//
+// `interval` is the scan cadence (env CONTROL_PLANE_INTERVAL); it is NOT the per-device
+// push cadence, which stays bounded by `onceIn` (ONCE_IN) via the OnceInPeriod dedup.
+func ScheduledCheckin(ctx context.Context, rc redislock.RedisClient, pushQueue taskq.Queue, onceIn, interval time.Duration) {
 	task := pushTask
 
 	// Wait for the initial device fetch to complete, but bail out immediately if
@@ -51,40 +60,33 @@ func ScheduledCheckin(ctx context.Context, pushQueue taskq.Queue, onceIn time.Du
 		}
 	}
 
-	var wg sync.WaitGroup
-	sem := make(chan int, 1)
-
-	minInterval := time.Minute
-
-	fn := func(sem chan int, wg *sync.WaitGroup) {
-		defer wg.Done()
-		start := time.Now()
-		log.Info("Running scheduled checkin")
-		err := processScheduledCheckin(pushQueue, task, onceIn)
+	run := func() {
+		if ctx.Err() != nil {
+			return
+		}
+		ran, err := withControlPlaneLock(ctx, rc, func(context.Context) error {
+			log.Info("Running scheduled checkin")
+			return processScheduledCheckin(pushQueue, task, onceIn)
+		})
 		if err != nil {
 			ErrorLogger(LogHolder{Message: err.Error()})
+			return
 		}
-		if elapsed := time.Since(start); elapsed < minInterval {
-			time.Sleep(minInterval - elapsed)
+		if !ran {
+			DebugLogger(LogHolder{Message: "Skipping scheduled checkin; another replica holds the control-plane lock"})
 		}
-		<-sem
 	}
 
+	// Run once immediately, then every interval, until shutdown.
+	run()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 	for {
-		// Check cancellation first so a shutdown signal always wins over
-		// scheduling another pass (select would otherwise pick randomly when
-		// both the semaphore and ctx.Done() are ready).
-		if ctx.Err() != nil {
-			wg.Wait()
-			return
-		}
 		select {
 		case <-ctx.Done():
-			wg.Wait()
 			return
-		case sem <- 1:
-			wg.Add(1)
-			go fn(sem, &wg)
+		case <-ticker.C:
+			run()
 		}
 	}
 }

--- a/director/schedule_push.go
+++ b/director/schedule_push.go
@@ -21,30 +21,33 @@ import (
 	"github.com/vmihailenco/taskq/v3"
 )
 
-func ScheduledCheckin(pushQueue taskq.Queue, onceIn time.Duration) {
+// pushTask is registered once at package load. taskq.RegisterTask panics on a
+// duplicate name, so it must not live inside ScheduledCheckin (which may be called
+// more than once, e.g. in tests).
+var pushTask = taskq.RegisterTask(&taskq.TaskOptions{
+	Name: "push",
+	Handler: func(uuid string) error {
+		err := PushDevice(uuid)
+		if err != nil {
+			ErrorLogger(LogHolder{Message: err.Error()})
+		}
+		return nil
+	},
+})
 
-	var task = taskq.RegisterTask(&taskq.TaskOptions{
-		Name: "push",
-		Handler: func(uuid string) error {
-			err := PushDevice(uuid)
-			if err != nil {
-				ErrorLogger(LogHolder{Message: err.Error()})
-			}
-			return nil
-		},
-	})
+func ScheduledCheckin(ctx context.Context, pushQueue taskq.Queue, onceIn time.Duration) {
+	task := pushTask
 
+	// Wait for the initial device fetch to complete, but bail out immediately if
+	// the process is shutting down.
 	counter := 0
-	for {
-		if !DevicesFetchedFromMDM {
-			time.Sleep(30 * time.Second)
+	for !DevicesFetchedFromMDM && counter <= 10 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(30 * time.Second):
 			log.Info("Devices are still being fetched from MicroMDM")
 			counter++
-			if counter > 10 {
-				break
-			}
-		} else {
-			break
 		}
 	}
 
@@ -68,20 +71,39 @@ func ScheduledCheckin(pushQueue taskq.Queue, onceIn time.Duration) {
 	}
 
 	for {
-		sem <- 1
-		wg.Add(1)
-		go fn(sem, &wg)
+		// Check cancellation first so a shutdown signal always wins over
+		// scheduling another pass (select would otherwise pick randomly when
+		// both the semaphore and ctx.Done() are ready).
+		if ctx.Err() != nil {
+			wg.Wait()
+			return
+		}
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		case sem <- 1:
+			wg.Add(1)
+			go fn(sem, &wg)
+		}
 	}
 }
 
-func ProcessScheduledCheckinQueue(pushQueue taskq.Queue) {
-	ctx := context.Background()
+func ProcessScheduledCheckinQueue(ctx context.Context, pushQueue taskq.Queue) {
 	p := pushQueue.Consumer()
 	DebugLogger(LogHolder{Message: "Processing items from scheduled checkin Queue"})
 	err := p.Start(ctx)
 	if err != nil {
 		msg := fmt.Errorf("starting consumer: %v", err.Error())
 		ErrorLogger(LogHolder{Message: msg.Error()})
+		return
+	}
+
+	// Start is non-blocking; keep this goroutine alive until shutdown, then
+	// drain in-flight work gracefully.
+	<-ctx.Done()
+	if err := p.Stop(); err != nil {
+		ErrorLogger(LogHolder{Message: fmt.Errorf("stopping consumer: %v", err.Error()).Error()})
 	}
 }
 

--- a/director/schedule_push_shutdown_test.go
+++ b/director/schedule_push_shutdown_test.go
@@ -20,9 +20,9 @@ func TestScheduledCheckinReturnsOnContextCancel(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		// pushQueue is nil; the cancelled context guarantees we return before
-		// ever dereferencing it.
-		ScheduledCheckin(ctx, nil, time.Minute)
+		// rc and pushQueue are nil; the cancelled context guarantees we return
+		// before ever dereferencing them.
+		ScheduledCheckin(ctx, nil, nil, time.Minute, time.Minute)
 		close(done)
 	}()
 
@@ -45,7 +45,7 @@ func TestScheduledCheckinReturnsWhileWaitingForDevices(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ScheduledCheckin(ctx, nil, time.Minute)
+		ScheduledCheckin(ctx, nil, nil, time.Minute, time.Minute)
 		close(done)
 	}()
 

--- a/director/schedule_push_shutdown_test.go
+++ b/director/schedule_push_shutdown_test.go
@@ -1,0 +1,61 @@
+package director
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestScheduledCheckinReturnsOnContextCancel verifies that ScheduledCheckin exits
+// promptly when its context is cancelled, instead of looping forever. The device
+// fetch flag is forced true so we skip the initial wait loop, and the context is
+// cancelled before we start so no scheduling pass (which would touch the DB) runs.
+func TestScheduledCheckinReturnsOnContextCancel(t *testing.T) {
+	prev := DevicesFetchedFromMDM
+	DevicesFetchedFromMDM = true
+	defer func() { DevicesFetchedFromMDM = prev }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		// pushQueue is nil; the cancelled context guarantees we return before
+		// ever dereferencing it.
+		ScheduledCheckin(ctx, nil, time.Minute)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// returned promptly, as expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("ScheduledCheckin did not return after context cancellation")
+	}
+}
+
+// TestScheduledCheckinReturnsWhileWaitingForDevices verifies that a shutdown while
+// still waiting for the initial device fetch also unblocks the wait loop.
+func TestScheduledCheckinReturnsWhileWaitingForDevices(t *testing.T) {
+	prev := DevicesFetchedFromMDM
+	DevicesFetchedFromMDM = false
+	defer func() { DevicesFetchedFromMDM = prev }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		ScheduledCheckin(ctx, nil, time.Minute)
+		close(done)
+	}()
+
+	// Give the goroutine a moment to enter the wait loop, then signal shutdown.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ScheduledCheckin did not return from the device-fetch wait loop on cancellation")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.24.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/alicebob/miniredis/v2 v2.38.0
+	github.com/bsm/redislock v0.7.2
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.3.0
@@ -25,7 +27,6 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bsm/redislock v0.7.2 // indirect
 	github.com/capnm/sysinfo v0.0.0-20130621111458-5909a53897f3 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -52,6 +53,7 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aws/aws-sdk-go v1.42.7 h1:Ee7QC4Y/eGebVGO/5IGN3fSXXSrheesZYYj2pYJG7Zk=
 github.com/aws/aws-sdk-go v1.42.7/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -358,6 +360,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/main.go
+++ b/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -592,15 +596,16 @@ func main() {
 		Name:  "pushnotifications",
 		Redis: director.RedisClient(), // go-redis client
 	})
-	err = PushQueue.Purge()
-	if err != nil {
-		log.Error(err)
-	}
 
 	if utils.Prometheus() {
 		director.PollGauges()
 		r.Handle("/metrics", promhttp.Handler())
 	}
+
+	// Root context cancelled on SIGINT/SIGTERM so background workers and the HTTP
+	// server shut down gracefully.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	go director.FetchDevicesFromMDM()
 
@@ -610,8 +615,24 @@ func main() {
 	}
 
 	onceInDuration := (time.Minute * time.Duration(OnceIn))
-	go director.ScheduledCheckin(PushQueue, onceInDuration)
-	go director.ProcessScheduledCheckinQueue(PushQueue)
+	go director.ScheduledCheckin(ctx, PushQueue, onceInDuration)
+	go director.ProcessScheduledCheckinQueue(ctx, PushQueue)
 
-	log.Info(http.ListenAndServe(":"+port, r))
+	srv := &http.Server{Addr: ":" + port, Handler: r}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Errorf("http server error: %v", err)
+		}
+	}()
+	director.InfoLogger(director.LogHolder{Message: "Listening on :" + port})
+
+	<-ctx.Done()
+	director.InfoLogger(director.LogHolder{Message: "Shutdown signal received, draining connections"})
+	stop() // restore default signal handling; a second signal now force-kills
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Errorf("graceful shutdown failed: %v", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -103,6 +103,9 @@ var RedisTLS bool
 
 var OnceIn int
 
+// ControlPlaneInterval is the number of minutes between fleet-wide control-plane scans
+var ControlPlaneInterval int
+
 var InfoRequestInterval int
 
 // AcmeCertIssuer is the issuer of the ACME certificate
@@ -334,6 +337,12 @@ func main() {
 		"once-in",
 		env.Int("ONCE_IN", 60),
 		"Number of minutes to wait before queuing an additional command for any device which already has commands queued. Defaults to 60. Ignored and overidden as 2 (minutes) if --debug is passed.",
+	)
+	flag.IntVar(
+		&ControlPlaneInterval,
+		"control-plane-interval",
+		env.Int("CONTROL_PLANE_INTERVAL", 120),
+		"Minutes between fleet-wide control-plane scans (device push scheduling + cleanup). Runs single-flight across replicas via a shared Redis lock. Defaults to 120.",
 	)
 	flag.IntVar(
 		&InfoRequestInterval,
@@ -592,9 +601,12 @@ func main() {
 
 	var QueueFactory = redisq.NewFactory()
 
+	// One shared go-redis client backs both the taskq queue and the control-plane lock.
+	redisClient := director.RedisClient()
+
 	var PushQueue = QueueFactory.RegisterQueue(&taskq.QueueOptions{
 		Name:  "pushnotifications",
-		Redis: director.RedisClient(), // go-redis client
+		Redis: redisClient, // go-redis client
 	})
 
 	if utils.Prometheus() {
@@ -615,7 +627,11 @@ func main() {
 	}
 
 	onceInDuration := (time.Minute * time.Duration(OnceIn))
-	go director.ScheduledCheckin(ctx, PushQueue, onceInDuration)
+	controlPlaneInterval := (time.Minute * time.Duration(ControlPlaneInterval))
+	if debugMode {
+		controlPlaneInterval = time.Minute
+	}
+	go director.ScheduledCheckin(ctx, redisClient, PushQueue, onceInDuration, controlPlaneInterval)
 	go director.ProcessScheduledCheckinQueue(ctx, PushQueue)
 
 	srv := &http.Server{Addr: ":" + port, Handler: r}


### PR DESCRIPTION
## Why

Second in the **stacked set** making mdmdirector horizontally scalable (Target A / leaderless). This is the core change: the periodic control-plane scan (device push scheduling + DB cleanup) now runs **once per interval fleet-wide** instead of continuously in every replica.

The data plane (the taskq consumer + taskq's own zset→stream promotion) already scales with pod count. Before this PR, `ScheduledCheckin` ran a tight per-pod loop doing a full-table `devices` scan + enqueue + cleanup `DELETE`/`UPDATE` at least once a minute — with N replicas that was N concurrent scanners racing on the same rows. This PR makes that control plane single-flight with automatic failover and **no leader election / no k8s RBAC** — coordination is the shared Redis they already run.

**Stack (merge in order):** #156 (graceful shutdown) → **this PR** → `wp/nanomdm/maintenance-backstop`. Base is `wp/nanomdm/graceful-shutdown`; retarget to `nanomdm` once #156 merges.

## What

- **`director/controlplane.go` — `withControlPlaneLock`.** Obtains a shared `bsm/redislock` key (`mdmdirector:control-plane`). Only the holder runs the scan; other replicas skip (`ran=false`). A background refresher keeps the lock alive during a long scan (`pushAll` paces itself with ~1m chunk sleeps); if the holder dies, the lock's TTL lets another replica take over on its next tick.
- **`ScheduledCheckin`** now takes a redis client + a scan `interval` and drives the scan from a `time.Ticker` (once immediately, then every interval), each run gated by the lock. The immediate run is skipped if the process is already shutting down.
- **`CONTROL_PLANE_INTERVAL`** flag/env (default `120` min; `1` min under `--debug`). This is the *scan cadence*, distinct from `ONCE_IN` which still bounds *per-device* push cadence via the `OnceInPeriod` dedup. Scan frequency no longer drives per-device push rate.
- `main` shares one go-redis client between the taskq queue and the lock.
- Promote `github.com/bsm/redislock` to a direct dependency (already used transitively by taskq); add `github.com/alicebob/miniredis/v2` as a test dependency.

## Tests

`director/controlplane_test.go` (miniredis-backed): a second replica is skipped while another holds the lock; after the holder releases/dies another replica acquires and runs (failover); the lock is released after each run. `go build/vet ./...` and `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)