### PR TITLE
feat: single-flight maintenance + fix dead NextPush push throttle

### DIFF
--- a/director/maintenance_test.go
+++ b/director/maintenance_test.go
@@ -1,0 +1,116 @@
+package director
+
+import (
+	"encoding/json"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/mdmdirector/mdmdirector/mdm"
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupOnceInFlag registers/sets the once-in flag so utils.OnceIn() works in tests.
+func setupOnceInFlag(t *testing.T) {
+	t.Helper()
+	if flag.Lookup("once-in") == nil {
+		flag.Int("once-in", 180, "once in")
+	} else {
+		_ = flag.Set("once-in", "180")
+	}
+}
+
+// TestRunCleanup verifies the maintenance mutations are issued in order: delete orphaned
+// certificates and profile lists, expire stale random unlock PINs, and reset fixed PINs.
+func TestRunCleanup(t *testing.T) {
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`DELETE FROM "certificates"`).WillReturnResult(sqlmock.NewResult(0, 0))
+	mockSpy.ExpectCommit()
+
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`DELETE FROM "profile_lists"`).WillReturnResult(sqlmock.NewResult(0, 0))
+	mockSpy.ExpectCommit()
+
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`DELETE FROM "unlock_pins"`).WillReturnResult(sqlmock.NewResult(0, 0))
+	mockSpy.ExpectCommit()
+
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`UPDATE "devices" SET "unlock_pin"`).WillReturnResult(sqlmock.NewResult(0, 0))
+	mockSpy.ExpectCommit()
+
+	err := runCleanup()
+	require.NoError(t, err)
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// TestUpdateNextPush verifies a device's next_push is persisted.
+func TestUpdateNextPush(t *testing.T) {
+	setupOnceInFlag(t)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`UPDATE "devices" SET "next_push"`).WillReturnResult(sqlmock.NewResult(0, 1))
+	mockSpy.ExpectCommit()
+
+	updateNextPush("test-udid")
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// TestPushDeviceUpdatesNextPush verifies a successful NanoMDM push persists next_push, so
+// the next control-plane scan skips the device until it is due again.
+func TestPushDeviceUpdatesNextPush(t *testing.T) {
+	setupNanoMDMFlag(t)
+	setupOnceInFlag(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := mdm.APIResponse{
+			Status: map[string]mdm.EnrollmentStatus{
+				"udid-abc": {PushResult: "success"},
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(server.Close)
+	mdm.InitClient(server.URL, "test-api-key")
+
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`UPDATE "devices" SET "next_push"`).WillReturnResult(sqlmock.NewResult(0, 1))
+	mockSpy.ExpectCommit()
+
+	err := PushDevice("udid-abc")
+	require.NoError(t, err)
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// TestDeviceNeedsPush verifies the NextPush guard actually throttles: a device with a
+// future NextPush is skipped, and one with a past NextPush is eligible again.
+func TestDeviceNeedsPush(t *testing.T) {
+	recent := types.Device{
+		UDID:                "recent",
+		NextPush:            time.Now().Add(1 * time.Hour),
+		LastCertificateList: time.Now(),
+		LastProfileList:     time.Now(),
+		LastSecurityInfo:    time.Now(),
+		LastDeviceInfo:      time.Now(),
+	}
+	assert.False(t, deviceNeedsPush(recent), "device pushed recently (future NextPush) should be skipped")
+
+	due := recent
+	due.UDID = "due"
+	due.NextPush = time.Now().Add(-1 * time.Hour)
+	assert.True(t, deviceNeedsPush(due), "device past its NextPush should be eligible")
+}

--- a/director/schedule_push.go
+++ b/director/schedule_push.go
@@ -47,25 +47,16 @@ var pushTask = taskq.RegisterTask(&taskq.TaskOptions{
 func ScheduledCheckin(ctx context.Context, rc redislock.RedisClient, pushQueue taskq.Queue, onceIn, interval time.Duration) {
 	task := pushTask
 
-	// Wait for the initial device fetch to complete, but bail out immediately if
-	// the process is shutting down.
-	counter := 0
-	for !DevicesFetchedFromMDM && counter <= 10 {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(30 * time.Second):
-			log.Info("Devices are still being fetched from MicroMDM")
-			counter++
-		}
-	}
-
 	run := func() {
 		if ctx.Err() != nil {
 			return
 		}
 		ran, err := withControlPlaneLock(ctx, rc, func(context.Context) error {
 			log.Info("Running scheduled checkin")
+			// Refresh the device inventory once per interval, fleet-wide, under the
+			// control-plane lock -- instead of once per replica at startup. Only the
+			// lock holder fetches, then scans and enqueues with fresh data.
+			FetchDevicesFromMDM()
 			return processScheduledCheckin(pushQueue, task, onceIn)
 		})
 		if err != nil {
@@ -119,30 +110,39 @@ func processScheduledCheckin(pushQueue taskq.Queue, task *taskq.Task, onceIn tim
 		return errors.Wrap(err, "processScheduledCheckin::pushAll")
 	}
 
+	return runCleanup()
+}
+
+// runCleanup performs the periodic DB maintenance mutations: removing orphaned
+// certificate/profile-list rows, expiring random unlock PINs older than 30 minutes, and
+// clearing fixed unlock PINs on devices that are no longer being erased/locked. It runs
+// under the control-plane lock, so exactly one replica performs these mutations per
+// interval instead of every replica racing on the same rows.
+func runCleanup() error {
 	var certificates []types.Certificate
 
-	err = db.DB.Unscoped().Model(&certificates).Where("device_ud_id is NULL").Delete(&types.Certificate{}).Error
+	err := db.DB.Unscoped().Model(&certificates).Where("device_ud_id is NULL").Delete(&types.Certificate{}).Error
 	if err != nil {
-		return errors.Wrap(err, "processScheduledCheckin::CleanupNullCertificates")
+		return errors.Wrap(err, "runCleanup::CleanupNullCertificates")
 	}
 
 	var profileLists []types.ProfileList
 
 	err = db.DB.Unscoped().Model(&profileLists).Where("device_ud_id is NULL").Delete(&types.ProfileList{}).Error
 	if err != nil {
-		return errors.Wrap(err, "processScheduledCheckin::CleanupNullProfileLists")
+		return errors.Wrap(err, "runCleanup::CleanupNullProfileLists")
 	}
 
 	thirtyMinsAgo := time.Now().Add(-30 * time.Minute)
 	err = db.DB.Where("unlock_pins.pin_set < ?", thirtyMinsAgo).Delete(&types.UnlockPin{}).Error
 	if err != nil {
-		return errors.Wrap(err, "processScheduledCheckin::DeleteRandomUnlockPins")
+		return errors.Wrap(err, "runCleanup::DeleteRandomUnlockPins")
 	}
 
 	var device types.Device
 	err = db.DB.Model(&device).Not("unlock_pin = ?", "").Where("erase = ? AND lock = ?", false, false).Update("unlock_pin", "").Error
 	if err != nil {
-		return errors.Wrap(err, "processScheduledCheckin::ResetFixedPin")
+		return errors.Wrap(err, "runCleanup::ResetFixedPin")
 	}
 
 	return nil
@@ -287,6 +287,27 @@ func PushDevice(udid string) (err error) {
 		}()
 	}
 
+	err = pushDevice(udid)
+	if err == nil {
+		// Record when this device is next eligible for a scheduled push. The
+		// control-plane scan (deviceNeedsPush) skips devices whose NextPush is still in
+		// the future, so this bounds per-device push cadence at ONCE_IN and stops
+		// pushAll re-enqueuing recently pushed devices on every scan.
+		updateNextPush(udid)
+	}
+	return err
+}
+
+// updateNextPush persists a device's next eligible scheduled-push time (now + ONCE_IN).
+// Best-effort: a failure is logged but does not fail the push that already succeeded.
+func updateNextPush(udid string) {
+	next := time.Now().Add(time.Minute * time.Duration(utils.OnceIn()))
+	if err := db.DB.Model(&types.Device{}).Where("ud_id = ?", udid).Update("next_push", next).Error; err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: errors.Wrap(err, "updateNextPush").Error()})
+	}
+}
+
+func pushDevice(udid string) error {
 	// Use NanoMDM client if enabled
 	if utils.MDMServerType() == string(mdm.ServerTypeNanoMDM) {
 		nanoClient, err := mdm.Client()

--- a/director/schedule_push_shutdown_test.go
+++ b/director/schedule_push_shutdown_test.go
@@ -34,14 +34,16 @@ func TestScheduledCheckinReturnsOnContextCancel(t *testing.T) {
 	}
 }
 
-// TestScheduledCheckinReturnsWhileWaitingForDevices verifies that a shutdown while
-// still waiting for the initial device fetch also unblocks the wait loop.
-func TestScheduledCheckinReturnsWhileWaitingForDevices(t *testing.T) {
+// TestScheduledCheckinReturnsWhenCancelledBeforeDeviceFetch verifies that a shutdown
+// signal is honoured even before any devices have been fetched: the run guard skips the
+// scan (so the nil redis client is never dereferenced) and the loop returns promptly.
+func TestScheduledCheckinReturnsWhenCancelledBeforeDeviceFetch(t *testing.T) {
 	prev := DevicesFetchedFromMDM
 	DevicesFetchedFromMDM = false
 	defer func() { DevicesFetchedFromMDM = prev }()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
 	done := make(chan struct{})
 	go func() {
@@ -49,13 +51,9 @@ func TestScheduledCheckinReturnsWhileWaitingForDevices(t *testing.T) {
 		close(done)
 	}()
 
-	// Give the goroutine a moment to enter the wait loop, then signal shutdown.
-	time.Sleep(50 * time.Millisecond)
-	cancel()
-
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("ScheduledCheckin did not return from the device-fetch wait loop on cancellation")
+		t.Fatal("ScheduledCheckin did not return on cancellation before the first device fetch")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -619,7 +619,8 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	go director.FetchDevicesFromMDM()
+	// Device inventory is refreshed inside the control-plane scan (single-flight under
+	// the Redis lock), not once per replica at startup -- see director.ScheduledCheckin.
 
 	// Override OnceIn if --debug is passed
 	if debugMode {


### PR DESCRIPTION
## Why

Final PR in the **stacked set** making mdmdirector horizontally scalable (Target A / leaderless). With the periodic scan now single-flight (#157), this folds the remaining per-replica work into that lock-gated scan and fixes the per-device push throttle that never worked.

**Stack (merge in order):** #156 → #157 → **this PR**. Base is `wp/nanomdm/single-flight-scheduler`; retarget to `nanomdm` after #157 merges.

## What

- **`runCleanup()`** — extracted the DB cleanup mutations (orphaned `certificates`/`profile_lists`, stale random unlock PINs, fixed-PIN reset) out of `processScheduledCheckin`. Still runs under the control-plane lock, so exactly **one** replica performs these mutations per interval instead of every replica racing on the same rows.
- **Device fetch is now single-flight.** `FetchDevicesFromMDM` moves off unconditional per-replica startup into the lock-gated scan: the inventory is refreshed once per interval fleet-wide by whichever replica holds the lock, not N times on every rollout. The old startup wait loop gating on `DevicesFetchedFromMDM` is gone — the scan fetches fresh data itself before enqueuing.
- **Fix the dead `device.NextPush` guard.** `NextPush` was read by `deviceNeedsPush` but only ever written as `now` (in initial tasks), so `now.Before(NextPush)` was always false and the guard never throttled. After a successful `PushDevice` we now persist `next_push = now + ONCE_IN` (new `updateNextPush`; `PushDevice` split into a thin wrapper over `pushDevice`). `deviceNeedsPush` now skips devices pushed within the last `ONCE_IN` window, so `pushAll` stops re-enqueuing them every scan — a DB-backed per-device throttle complementing the Redis `OnceInPeriod` dedup, with less scan/enqueue churn.

## Tests

`director/maintenance_test.go`: `runCleanup` issues the expected DELETE/UPDATE sequence (sqlmock); `updateNextPush` and a successful `PushDevice` persist `next_push`; `deviceNeedsPush` skips a device with a future `NextPush` and re-includes one past it. `go build/vet ./...`, `go test ./...` all green.

## Follow-up (not in this stack)

Before actually raising replica counts in `nucleus-app-mdmv2`, the mdmdirector ElastiCache parameter group must be `maxmemory-policy noeviction` (the authoritative schedule + dedup keys live in Redis under Target A). That HPA/PDB + param-group change is a separate infra PR, per `projects/mdmdirector/CONCURRENCY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)