### PR TITLE
Spread scheduled pushes via message delay instead of sleeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ These flags enable Declarative Device Management via KMFDDM. DDM requires `mdm-s
 
 - `-push-new-build` - Re-push profiles if the device's build number changes. (default true) Env: `PUSH_NEW_BUILD`
 - `-once-in int` - Minutes to wait before queuing additional commands for a device with pending commands. (default 60, overridden to 2 if --debug) Env: `ONCE_IN`
-- `-push-spread int` - Minutes over which the scheduled pushes are spread out for delivery. Each device's push is delayed by `once-in` plus a random offset within this window, so a fleet-wide scan does not deliver every push at once. (default 30, overridden to 1 if --debug) Env: `PUSH_SPREAD`
+- `-push-spread int` - Minutes over which the scheduled pushes are spread out for delivery. Each device's push is delayed by a random offset within this window, so a fleet-wide scan does not deliver every push at once. Must be less than `control-plane-interval` (clamped to half of it if not), so the window closes before the next scan starts. (default 90, overridden to 0 — immediate — if --debug) Env: `PUSH_SPREAD`
 - `-info-request-interval int` - Minutes between issuing DeviceInfo, ProfileList, SecurityInfo commands. (default 360) Env: `INFO_REQUEST_INTERVAL`
 
 #### PIN Escrow

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ These flags enable Declarative Device Management via KMFDDM. DDM requires `mdm-s
 
 - `-push-new-build` - Re-push profiles if the device's build number changes. (default true) Env: `PUSH_NEW_BUILD`
 - `-once-in int` - Minutes to wait before queuing additional commands for a device with pending commands. (default 60, overridden to 2 if --debug) Env: `ONCE_IN`
+- `-push-spread int` - Minutes over which the scheduled pushes are spread out for delivery. Each device's push is delayed by `once-in` plus a random offset within this window, so a fleet-wide scan does not deliver every push at once. (default 30, overridden to 1 if --debug) Env: `PUSH_SPREAD`
 - `-info-request-interval int` - Minutes between issuing DeviceInfo, ProfileList, SecurityInfo commands. (default 360) Env: `INFO_REQUEST_INTERVAL`
 
 #### PIN Escrow

--- a/director/background_tasks.go
+++ b/director/background_tasks.go
@@ -24,17 +24,6 @@ var DevicesFetchedFromMDM bool
 
 var client = &http.Client{}
 
-// The delay between looping over the background goroutines (sending push notifications etc)
-func getDelay() time.Duration {
-	DelaySeconds := 7200
-
-	if utils.DebugMode() {
-		DelaySeconds = 20
-	}
-
-	return time.Duration(DelaySeconds)
-}
-
 func UnconfiguredDevices() {
 	ticker := time.NewTicker(30 * time.Second)
 

--- a/director/controlplane.go
+++ b/director/controlplane.go
@@ -16,8 +16,8 @@ const (
 	controlPlaneLockKey = "mdmdirector:control-plane"
 
 	// controlPlaneLockTTL is how long the lock is held before it must be refreshed. A
-	// scan can run for many minutes (pushAll paces itself with ~1m sleeps per chunk), so
-	// a background refresher keeps the lock alive while the holder works. If the holder
+	// scan is normally quick (pushAll enqueues without sleeping), but a background
+	// refresher keeps the lock alive while the holder works. If the holder
 	// dies mid-scan, the lock expires within this TTL and another pod takes over on its
 	// next tick -- automatic failover, no SPOF.
 	controlPlaneLockTTL = 30 * time.Second

--- a/director/schedule_push.go
+++ b/director/schedule_push.go
@@ -3,7 +3,7 @@ package director
 import (
 	"context"
 	"fmt"
-	"math"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"path"
@@ -44,7 +44,9 @@ var pushTask = taskq.RegisterTask(&taskq.TaskOptions{
 //
 // `interval` is the scan cadence (env CONTROL_PLANE_INTERVAL); it is NOT the per-device
 // push cadence, which stays bounded by `onceIn` (ONCE_IN) via the OnceInPeriod dedup.
-func ScheduledCheckin(ctx context.Context, rc redislock.RedisClient, pushQueue taskq.Queue, onceIn, interval time.Duration) {
+// `pushSpread` (PUSH_SPREAD) is the window across which the enqueued pushes are spread
+// out for delivery; see pushAll.
+func ScheduledCheckin(ctx context.Context, rc redislock.RedisClient, pushQueue taskq.Queue, onceIn, pushSpread, interval time.Duration) {
 	task := pushTask
 
 	run := func() {
@@ -57,7 +59,7 @@ func ScheduledCheckin(ctx context.Context, rc redislock.RedisClient, pushQueue t
 			// control-plane lock -- instead of once per replica at startup. Only the
 			// lock holder fetches, then scans and enqueues with fresh data.
 			FetchDevicesFromMDM()
-			return processScheduledCheckin(pushQueue, task, onceIn)
+			return processScheduledCheckin(pushQueue, task, onceIn, pushSpread)
 		})
 		if err != nil {
 			ErrorLogger(LogHolder{Message: err.Error()})
@@ -100,12 +102,12 @@ func ProcessScheduledCheckinQueue(ctx context.Context, pushQueue taskq.Queue) {
 	}
 }
 
-func processScheduledCheckin(pushQueue taskq.Queue, task *taskq.Task, onceIn time.Duration) error {
+func processScheduledCheckin(pushQueue taskq.Queue, task *taskq.Task, onceIn, pushSpread time.Duration) error {
 	if utils.DebugMode() {
 		DebugLogger(LogHolder{Message: "Processing scheduledCheckin in debug mode"})
 	}
 
-	err := pushAll(pushQueue, task, onceIn)
+	err := pushAll(pushQueue, task, onceIn, pushSpread)
 	if err != nil {
 		return errors.Wrap(err, "processScheduledCheckin::pushAll")
 	}
@@ -148,28 +150,19 @@ func runCleanup() error {
 	return nil
 }
 
-func deviceChunkSlice(slice []types.Device, chunkSize int) [][]types.Device {
-	var chunks [][]types.Device
-	for i := 0; i < len(slice); i += chunkSize {
-		end := i + chunkSize
-
-		// necessary check to avoid slicing beyond
-		// slice capacity
-		if end > len(slice) {
-			end = len(slice)
-		}
-
-		chunks = append(chunks, slice[i:end])
-	}
-
-	return chunks
-}
-
-func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn time.Duration) error {
+// pushAll enqueues every device that is due for a scheduled push. It does not sleep:
+// the scan itself finishes in seconds (so the control-plane lock is held only briefly),
+// and the load is spread out by *delaying delivery* of each message instead. Each
+// message gets a delay of onceIn + rand[0, pushSpread), which taskq stores as a due
+// time in a Redis zset, so the consumer picks the pushes up gradually across the
+// pushSpread window rather than all at once.
+//
+// OnceInPeriod still provides fleet-wide, per-device dedup for the onceIn window: it
+// derives the message name from the args + period + time slot. It also sets Delay, which
+// the following SetDelay overrides -- the name (and therefore the dedup) is unaffected.
+func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn, pushSpread time.Duration) error {
 	var devices []types.Device
 	var dbDevices []types.Device
-
-	DelaySeconds := getDelay() // nolint:staticcheck
 
 	err := db.DB.Find(&dbDevices).Scan(&dbDevices).Error
 	if err != nil {
@@ -196,54 +189,40 @@ func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn time.Duration) erro
 		Message: "Pushing to all in debug mode",
 	})
 
-	counter := 0
-	total := 0
-	devicesPerSecond := float64(len(devices)) / float64((DelaySeconds - 1))
-	DebugLogger(LogHolder{Message: "Processed devices per 0.5 seconds", Metric: strconv.Itoa(int(devicesPerSecond))})
-
-	devicesPerMinute := int(math.Ceil(float64(len(devices)) / 60))
-	InfoLogger(LogHolder{Message: fmt.Sprintf("%d will be processed each minute", devicesPerMinute)})
-	deviceChunks := deviceChunkSlice(devices, devicesPerMinute)
-	InfoLogger(LogHolder{Message: fmt.Sprintf("%d chunks of %d devices each will be processed", len(deviceChunks), devicesPerMinute)})
 	ctx := context.Background()
-	msgTxt := fmt.Sprintf("commands will only be queued for an individual device every %s at maximum", onceIn)
-	InfoLogger(LogHolder{Message: msgTxt})
-	for i := range deviceChunks {
-		for j := range deviceChunks[i] {
-			device := deviceChunks[i][j]
-			if float64(counter) >= devicesPerSecond {
-				DebugLogger(LogHolder{Message: "Sleeping due to having processed devices", Metric: strconv.Itoa(total)})
-				time.Sleep(500 * time.Millisecond)
-				counter = 0
-			}
-			DebugLogger(LogHolder{Message: "pushAll processed", Metric: strconv.Itoa(counter)})
+	InfoLogger(LogHolder{Message: fmt.Sprintf("commands will only be queued for an individual device every %s at maximum", onceIn)})
+	InfoLogger(LogHolder{Message: fmt.Sprintf("%d pushes will be spread over %s", len(devices), pushSpread)})
 
-			msg := task.WithArgs(ctx, device.UDID)
+	for i := range devices {
+		device := devices[i]
 
-			msg.OnceInPeriod(onceIn)
-			err := pushQueue.Add(msg)
-			switch {
-			case errors.Is(msg.Err, taskq.ErrDuplicate):
-				// handle duplicate task
-				DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: msg.Err.Error()})
-			case err != nil:
-				ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
-			case msg.Err != nil:
-				// handle duplicate task
-				ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: msg.Err.Error()})
-			}
+		msg := task.WithArgs(ctx, device.UDID)
+		// Sets the dedup name from the args, period and time slot -- and Delay, which
+		// the SetDelay below then overrides without touching the name.
+		msg.OnceInPeriod(onceIn, device.UDID)
+		msg.SetDelay(onceIn + jitter(pushSpread))
 
-			counter++
-			total++
+		err := pushQueue.Add(msg)
+		switch {
+		case errors.Is(msg.Err, taskq.ErrDuplicate):
+			// handle duplicate task
+			DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: msg.Err.Error()})
+		case err != nil:
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: err.Error()})
+		case msg.Err != nil:
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: msg.Err.Error()})
 		}
-		// Wait 1 minute before processing the next chunk of devices
-		msg := fmt.Sprintf("%d/%d devices processed", (i+1)*devicesPerMinute, len(devices))
-		InfoLogger(LogHolder{Message: msg})
-		InfoLogger(LogHolder{Message: "Sleeping 1 minute before processing next chunk of devices"})
-		time.Sleep(time.Minute * 1)
 	}
 	InfoLogger(LogHolder{Message: "Completed scheduling pushes", Metric: strconv.Itoa(len(devices))})
 	return nil
+}
+
+// jitter returns a random duration in [0, spread). A non-positive spread yields 0.
+func jitter(spread time.Duration) time.Duration {
+	if spread <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(spread))) // nolint:gosec // not security sensitive
 }
 
 func deviceNeedsPush(device types.Device) bool {

--- a/director/schedule_push.go
+++ b/director/schedule_push.go
@@ -164,7 +164,7 @@ func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn, pushSpread time.Du
 	var devices []types.Device
 	var dbDevices []types.Device
 
-	err := db.DB.Find(&dbDevices).Scan(&dbDevices).Error
+	err := db.DB.Find(&dbDevices).Error
 	if err != nil {
 		return errors.Wrap(err, "PushAll: Scan devices")
 	}

--- a/director/schedule_push.go
+++ b/director/schedule_push.go
@@ -153,13 +153,17 @@ func runCleanup() error {
 // pushAll enqueues every device that is due for a scheduled push. It does not sleep:
 // the scan itself finishes in seconds (so the control-plane lock is held only briefly),
 // and the load is spread out by *delaying delivery* of each message instead. Each
-// message gets a delay of onceIn + rand[0, pushSpread), which taskq stores as a due
-// time in a Redis zset, so the consumer picks the pushes up gradually across the
-// pushSpread window rather than all at once.
+// message gets a delay of rand[0, pushSpread), which taskq stores as a due time in a
+// Redis zset, so the consumer picks the pushes up gradually across the pushSpread window
+// rather than all at once.
 //
-// OnceInPeriod still provides fleet-wide, per-device dedup for the onceIn window: it
-// derives the message name from the args + period + time slot. It also sets Delay, which
-// the following SetDelay overrides -- the name (and therefore the dedup) is unaffected.
+// The delay is deliberately not offset by onceIn: per-device cadence is enforced by
+// NextPush/deviceNeedsPush and by the OnceInPeriod dedup, so an extra onceIn of delay
+// would only make every push a full cadence late.
+//
+// OnceInPeriod provides fleet-wide, per-device dedup for the onceIn window: it derives
+// the message name from the args + period + time slot. It also sets Delay, which the
+// following SetDelay overrides -- the name (and therefore the dedup) is unaffected.
 func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn, pushSpread time.Duration) error {
 	var devices []types.Device
 	var dbDevices []types.Device
@@ -179,7 +183,9 @@ func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn, pushSpread time.Du
 		needsPush := deviceNeedsPush(device)
 
 		if needsPush {
-			InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Adding Device to push list"})
+			// Debug, not Info: with the pacing sleeps gone this loop emits one line per
+			// device in the fleet within a couple of seconds.
+			DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Adding Device to push list"})
 			devices = append(devices, device)
 		}
 
@@ -193,6 +199,14 @@ func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn, pushSpread time.Du
 	InfoLogger(LogHolder{Message: fmt.Sprintf("commands will only be queued for an individual device every %s at maximum", onceIn)})
 	InfoLogger(LogHolder{Message: fmt.Sprintf("%d pushes will be spread over %s", len(devices), pushSpread)})
 
+	// Reserve before enqueuing: the messages below are not delivered until up to
+	// pushSpread from now, and NextPush is otherwise only written once a push has
+	// actually been sent. Without this, a scan that starts while the previous scan's
+	// messages are still pending would see a stale NextPush and enqueue them again --
+	// and the dedup name may well have rolled into a new time slot by then, so the
+	// duplicate would not be suppressed.
+	reserveNextPush(devices, onceIn, pushSpread)
+
 	for i := range devices {
 		device := devices[i]
 
@@ -200,7 +214,7 @@ func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn, pushSpread time.Du
 		// Sets the dedup name from the args, period and time slot -- and Delay, which
 		// the SetDelay below then overrides without touching the name.
 		msg.OnceInPeriod(onceIn, device.UDID)
-		msg.SetDelay(onceIn + jitter(pushSpread))
+		msg.SetDelay(jitter(pushSpread))
 
 		err := pushQueue.Add(msg)
 		switch {
@@ -217,6 +231,36 @@ func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn, pushSpread time.Du
 	return nil
 }
 
+// reserveNextPushBatch is how many UDIDs go into one `next_push` UPDATE. Keeps the IN
+// clause a sane size on large fleets without issuing a statement per device.
+const reserveNextPushBatch = 1000
+
+// reserveNextPush marks the given devices as not due again until the whole spread window
+// has elapsed plus one onceIn cadence -- i.e. until the pushes being enqueued now must
+// have been delivered. It is deliberately conservative: every device gets the end of the
+// window rather than its own delay, so this is one UPDATE per batch instead of one per
+// device. Once a push is actually sent, updateNextPush overwrites this with the
+// authoritative now+onceIn.
+//
+// Best-effort: a failure is logged and the scan continues, exactly like updateNextPush.
+func reserveNextPush(devices []types.Device, onceIn, pushSpread time.Duration) {
+	next := time.Now().Add(pushSpread + onceIn)
+
+	for start := 0; start < len(devices); start += reserveNextPushBatch {
+		end := min(start+reserveNextPushBatch, len(devices))
+
+		udids := make([]string, 0, end-start)
+		for _, device := range devices[start:end] {
+			udids = append(udids, device.UDID)
+		}
+
+		err := db.DB.Model(&types.Device{}).Where("ud_id IN ?", udids).Update("next_push", next).Error
+		if err != nil {
+			ErrorLogger(LogHolder{Message: errors.Wrap(err, "reserveNextPush").Error()})
+		}
+	}
+}
+
 // jitter returns a random duration in [0, spread). A non-positive spread yields 0.
 func jitter(spread time.Duration) time.Duration {
 	if spread <= 0 {
@@ -229,21 +273,22 @@ func deviceNeedsPush(device types.Device) bool {
 	now := time.Now()
 	oneDayAgo := time.Now().Add(-24 * time.Hour)
 
-	InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Considering device for scheduled push"})
+	// Debug, not Info: this runs once per device in the fleet per scan, all at once.
+	DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Considering device for scheduled push"})
 
 	if now.Before(device.NextPush) && !device.NextPush.IsZero() {
-		InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Not Pushing. Next push is in metric", Metric: device.NextPush.String()})
+		DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Not Pushing. Next push is in metric", Metric: device.NextPush.String()})
 		return false
 	}
 
 	if device.LastCertificateList.IsZero() || device.LastProfileList.IsZero() || device.LastSecurityInfo.IsZero() || device.LastDeviceInfo.IsZero() {
-		InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "One or more of the info commands hasn't ever been received"})
+		DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "One or more of the info commands hasn't ever been received"})
 		return true
 	}
 
 	// We've not had all of the info payloads within the last day
 	if (device.LastCertificateList.Before(oneDayAgo) || device.LastProfileList.Before(oneDayAgo) || device.LastSecurityInfo.Before(oneDayAgo) || device.LastDeviceInfo.Before(oneDayAgo)) && (!device.LastCertificateList.IsZero() && !device.LastProfileList.IsZero() && !device.LastSecurityInfo.IsZero() && !device.LastDeviceInfo.IsZero()) {
-		InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Have not received all of the info commands within the last six hours."})
+		DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "Have not received all of the info commands within the last six hours."})
 		return true
 	}
 

--- a/director/schedule_push_shutdown_test.go
+++ b/director/schedule_push_shutdown_test.go
@@ -22,7 +22,7 @@ func TestScheduledCheckinReturnsOnContextCancel(t *testing.T) {
 	go func() {
 		// rc and pushQueue are nil; the cancelled context guarantees we return
 		// before ever dereferencing them.
-		ScheduledCheckin(ctx, nil, nil, time.Minute, time.Minute)
+		ScheduledCheckin(ctx, nil, nil, time.Minute, time.Minute, time.Minute)
 		close(done)
 	}()
 
@@ -47,7 +47,7 @@ func TestScheduledCheckinReturnsWhenCancelledBeforeDeviceFetch(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		ScheduledCheckin(ctx, nil, nil, time.Minute, time.Minute)
+		ScheduledCheckin(ctx, nil, nil, time.Minute, time.Minute, time.Minute)
 		close(done)
 	}()
 

--- a/director/schedule_push_spread_test.go
+++ b/director/schedule_push_spread_test.go
@@ -30,25 +30,19 @@ func (q *fakeQueue) Add(msg *taskq.Message) error {
 	return nil
 }
 
-// expectDeviceScan stubs the `db.DB.Find(&devices).Scan(&devices)` in pushAll, returning
-// `count` devices whose info-command timestamps are all zero (so deviceNeedsPush is true).
-// `Find(&x).Scan(&x)` runs the same statement twice, so both runs are stubbed.
+// expectDeviceScan stubs the `db.DB.Find(&devices)` in pushAll, returning `count` devices
+// whose info-command timestamps are all zero (so deviceNeedsPush is true). Exactly one
+// query is expected, which also pins the fix for the duplicated read pushAll used to do.
 func expectDeviceScan(mockSpy sqlmock.Sqlmock, count int) []string {
 	udids := make([]string, 0, count)
+	rows := sqlmock.NewRows([]string{"ud_id", "serial_number"})
 	for i := 0; i < count; i++ {
-		udids = append(udids, fmt.Sprintf("UDID-%04d", i))
+		udid := fmt.Sprintf("UDID-%04d", i)
+		udids = append(udids, udid)
+		rows.AddRow(udid, fmt.Sprintf("SERIAL%04d", i))
 	}
 
-	newRows := func() *sqlmock.Rows {
-		rows := sqlmock.NewRows([]string{"ud_id", "serial_number"})
-		for i, udid := range udids {
-			rows.AddRow(udid, fmt.Sprintf("SERIAL%04d", i))
-		}
-		return rows
-	}
-
-	mockSpy.ExpectQuery(`SELECT \* FROM "devices"`).WillReturnRows(newRows())
-	mockSpy.ExpectQuery(`SELECT \* FROM "devices"`).WillReturnRows(newRows())
+	mockSpy.ExpectQuery(`SELECT \* FROM "devices"`).WillReturnRows(rows)
 	return udids
 }
 

--- a/director/schedule_push_spread_test.go
+++ b/director/schedule_push_spread_test.go
@@ -1,6 +1,7 @@
 package director
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -33,6 +34,7 @@ func (q *fakeQueue) Add(msg *taskq.Message) error {
 // expectDeviceScan stubs the `db.DB.Find(&devices)` in pushAll, returning `count` devices
 // whose info-command timestamps are all zero (so deviceNeedsPush is true). Exactly one
 // query is expected, which also pins the fix for the duplicated read pushAll used to do.
+// It then stubs the batched `next_push` reservation writes.
 func expectDeviceScan(mockSpy sqlmock.Sqlmock, count int) []string {
 	udids := make([]string, 0, count)
 	rows := sqlmock.NewRows([]string{"ud_id", "serial_number"})
@@ -43,6 +45,14 @@ func expectDeviceScan(mockSpy sqlmock.Sqlmock, count int) []string {
 	}
 
 	mockSpy.ExpectQuery(`SELECT \* FROM "devices"`).WillReturnRows(rows)
+
+	for remaining := count; remaining > 0; remaining -= reserveNextPushBatch {
+		mockSpy.ExpectBegin()
+		mockSpy.ExpectExec(`UPDATE "devices" SET "next_push"`).
+			WillReturnResult(sqlmock.NewResult(0, int64(min(remaining, reserveNextPushBatch))))
+		mockSpy.ExpectCommit()
+	}
+
 	return udids
 }
 
@@ -54,7 +64,7 @@ func TestPushAllSpreadsDelaysWithoutSleeping(t *testing.T) {
 	udids := expectDeviceScan(mockSpy, deviceCount)
 
 	onceIn := 60 * time.Minute
-	pushSpread := 30 * time.Minute
+	pushSpread := 90 * time.Minute
 
 	queue := &fakeQueue{}
 	task := taskq.RegisterTask(&taskq.TaskOptions{
@@ -77,9 +87,9 @@ func TestPushAllSpreadsDelaysWithoutSleeping(t *testing.T) {
 	for i, msg := range queue.added {
 		assert.Equal(t, udids[i], msg.Args[0], "messages enqueued in device order")
 
-		// Delivery is delayed by at least onceIn and at most onceIn+pushSpread.
-		assert.GreaterOrEqual(t, msg.Delay, onceIn, "delay below onceIn for %s", udids[i])
-		assert.Less(t, msg.Delay, onceIn+pushSpread, "delay beyond the spread window for %s", udids[i])
+		// Delivery lands inside the spread window, with no onceIn offset in front of it.
+		assert.GreaterOrEqual(t, msg.Delay, time.Duration(0), "negative delay for %s", udids[i])
+		assert.Less(t, msg.Delay, pushSpread, "delay beyond the spread window for %s", udids[i])
 
 		// OnceInPeriod's dedup name must survive the SetDelay override.
 		require.NotEmpty(t, msg.Name, "dedup name missing for %s", udids[i])
@@ -96,7 +106,7 @@ func TestPushAllSpreadsDelaysWithoutSleeping(t *testing.T) {
 	require.NoError(t, mockSpy.ExpectationsWereMet())
 }
 
-func TestPushAllZeroSpreadUsesOnceInDelay(t *testing.T) {
+func TestPushAllZeroSpreadDeliversImmediately(t *testing.T) {
 	mockSpy, cleanup := setupMockDB(t)
 	defer cleanup()
 
@@ -111,9 +121,10 @@ func TestPushAllZeroSpreadUsesOnceInDelay(t *testing.T) {
 
 	require.NoError(t, pushAll(queue, task, onceIn, 0))
 
+	// A zero spread (debug mode) means no delay at all, not a one-cadence wait.
 	require.Len(t, queue.added, 3)
 	for _, msg := range queue.added {
-		assert.Equal(t, onceIn, msg.Delay)
+		assert.Zero(t, msg.Delay)
 		assert.NotEmpty(t, msg.Name)
 	}
 
@@ -164,4 +175,53 @@ func TestPushAllHasNoSleeps(t *testing.T) {
 		}
 		return true
 	})
+}
+
+// argMatcher adapts a func to go-sqlmock's Argument interface.
+type argMatcher func(driver.Value) bool
+
+func (m argMatcher) Match(v driver.Value) bool { return m(v) }
+
+// TestPushAllReservesNextPushBeforeEnqueuing pins the guard against a scan re-enqueuing
+// devices whose pushes are still sitting in the zset: NextPush is written for the whole
+// delivery window (pushSpread + onceIn) up front, not after the push is delivered.
+func TestPushAllReservesNextPushBeforeEnqueuing(t *testing.T) {
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	onceIn := 60 * time.Minute
+	pushSpread := 90 * time.Minute
+	queue := &fakeQueue{}
+
+	rows := sqlmock.NewRows([]string{"ud_id", "serial_number"}).AddRow("UDID-1", "SERIAL1")
+	mockSpy.ExpectQuery(`SELECT \* FROM "devices"`).WillReturnRows(rows)
+
+	addsWhenReserved := -1
+	expectedNext := time.Now().Add(pushSpread + onceIn)
+
+	mockSpy.ExpectBegin()
+	mockSpy.ExpectExec(`UPDATE "devices" SET "next_push"`).
+		WithArgs(
+			argMatcher(func(v driver.Value) bool {
+				// Reservation must happen before anything is handed to the queue.
+				addsWhenReserved = len(queue.added)
+				next, ok := v.(time.Time)
+				return ok && next.Sub(expectedNext).Abs() < time.Minute
+			}),
+			sqlmock.AnyArg(), // updated_at, set by gorm
+			"UDID-1",
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mockSpy.ExpectCommit()
+
+	task := taskq.RegisterTask(&taskq.TaskOptions{
+		Name:    "push-reserve-test",
+		Handler: func(string) error { return nil },
+	})
+
+	require.NoError(t, pushAll(queue, task, onceIn, pushSpread))
+
+	require.NoError(t, mockSpy.ExpectationsWereMet())
+	assert.Equal(t, 0, addsWhenReserved, "next_push must be reserved before the first enqueue")
+	assert.Len(t, queue.added, 1)
 }

--- a/director/schedule_push_spread_test.go
+++ b/director/schedule_push_spread_test.go
@@ -1,0 +1,173 @@
+package director
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/taskq/v3"
+)
+
+// fakeQueue is a taskq.Queue that only records the messages passed to Add, so tests can
+// inspect the delay and dedup name pushAll assigned to each one.
+type fakeQueue struct {
+	taskq.Queue
+	added []*taskq.Message
+}
+
+func (q *fakeQueue) Name() string { return "fake" }
+
+func (q *fakeQueue) String() string { return "fakeQueue" }
+
+func (q *fakeQueue) Add(msg *taskq.Message) error {
+	q.added = append(q.added, msg)
+	return nil
+}
+
+// expectDeviceScan stubs the `db.DB.Find(&devices).Scan(&devices)` in pushAll, returning
+// `count` devices whose info-command timestamps are all zero (so deviceNeedsPush is true).
+// `Find(&x).Scan(&x)` runs the same statement twice, so both runs are stubbed.
+func expectDeviceScan(mockSpy sqlmock.Sqlmock, count int) []string {
+	udids := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		udids = append(udids, fmt.Sprintf("UDID-%04d", i))
+	}
+
+	newRows := func() *sqlmock.Rows {
+		rows := sqlmock.NewRows([]string{"ud_id", "serial_number"})
+		for i, udid := range udids {
+			rows.AddRow(udid, fmt.Sprintf("SERIAL%04d", i))
+		}
+		return rows
+	}
+
+	mockSpy.ExpectQuery(`SELECT \* FROM "devices"`).WillReturnRows(newRows())
+	mockSpy.ExpectQuery(`SELECT \* FROM "devices"`).WillReturnRows(newRows())
+	return udids
+}
+
+func TestPushAllSpreadsDelaysWithoutSleeping(t *testing.T) {
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	const deviceCount = 200
+	udids := expectDeviceScan(mockSpy, deviceCount)
+
+	onceIn := 60 * time.Minute
+	pushSpread := 30 * time.Minute
+
+	queue := &fakeQueue{}
+	task := taskq.RegisterTask(&taskq.TaskOptions{
+		Name:    "push-spread-test",
+		Handler: func(string) error { return nil },
+	})
+
+	start := time.Now()
+	require.NoError(t, pushAll(queue, task, onceIn, pushSpread))
+	elapsed := time.Since(start)
+
+	// No sleeps: enqueuing 200 devices must not take anywhere near the old
+	// 500ms-per-batch / 1-minute-per-chunk pacing.
+	assert.Less(t, elapsed, 5*time.Second, "pushAll should not sleep while enqueuing")
+
+	require.Len(t, queue.added, deviceCount)
+
+	seenNames := make(map[string]struct{}, deviceCount)
+	distinctDelays := make(map[time.Duration]struct{})
+	for i, msg := range queue.added {
+		assert.Equal(t, udids[i], msg.Args[0], "messages enqueued in device order")
+
+		// Delivery is delayed by at least onceIn and at most onceIn+pushSpread.
+		assert.GreaterOrEqual(t, msg.Delay, onceIn, "delay below onceIn for %s", udids[i])
+		assert.Less(t, msg.Delay, onceIn+pushSpread, "delay beyond the spread window for %s", udids[i])
+
+		// OnceInPeriod's dedup name must survive the SetDelay override.
+		require.NotEmpty(t, msg.Name, "dedup name missing for %s", udids[i])
+		_, dup := seenNames[msg.Name]
+		assert.False(t, dup, "duplicate dedup name for %s", udids[i])
+		seenNames[msg.Name] = struct{}{}
+
+		distinctDelays[msg.Delay] = struct{}{}
+	}
+
+	// Jitter should actually spread the pushes out rather than clumping them.
+	assert.Greater(t, len(distinctDelays), 1, "expected pushes to be spread across the window")
+
+	require.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+func TestPushAllZeroSpreadUsesOnceInDelay(t *testing.T) {
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	expectDeviceScan(mockSpy, 3)
+
+	onceIn := 15 * time.Minute
+	queue := &fakeQueue{}
+	task := taskq.RegisterTask(&taskq.TaskOptions{
+		Name:    "push-zero-spread-test",
+		Handler: func(string) error { return nil },
+	})
+
+	require.NoError(t, pushAll(queue, task, onceIn, 0))
+
+	require.Len(t, queue.added, 3)
+	for _, msg := range queue.added {
+		assert.Equal(t, onceIn, msg.Delay)
+		assert.NotEmpty(t, msg.Name)
+	}
+
+	require.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+func TestPushAllNoDevicesEnqueuesNothing(t *testing.T) {
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	expectDeviceScan(mockSpy, 0)
+
+	queue := &fakeQueue{}
+	task := taskq.RegisterTask(&taskq.TaskOptions{
+		Name:    "push-no-devices-test",
+		Handler: func(string) error { return nil },
+	})
+
+	require.NoError(t, pushAll(queue, task, time.Minute, time.Minute))
+	assert.Empty(t, queue.added)
+	require.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// TestPushAllHasNoSleeps guards the invariant that made the control-plane scan slow: any
+// time.Sleep in pushAll blocks the scan while it holds the control-plane Redis lock.
+func TestPushAllHasNoSleeps(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "schedule_push.go", nil, 0)
+	require.NoError(t, err)
+
+	var fn *ast.FuncDecl
+	for _, decl := range file.Decls {
+		if d, ok := decl.(*ast.FuncDecl); ok && d.Name.Name == "pushAll" {
+			fn = d
+			break
+		}
+	}
+	require.NotNil(t, fn, "pushAll not found in schedule_push.go")
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if ok && pkg.Name == "time" && sel.Sel.Name == "Sleep" {
+			t.Errorf("pushAll must not sleep: found time.Sleep at %s", fset.Position(sel.Pos()))
+		}
+		return true
+	})
+}

--- a/main.go
+++ b/main.go
@@ -344,8 +344,8 @@ func main() {
 	flag.IntVar(
 		&PushSpread,
 		"push-spread",
-		env.Int("PUSH_SPREAD", 30),
-		"Number of minutes over which the scheduled pushes are spread out for delivery. Each device's push is delayed by ONCE_IN plus a random offset within this window, so a fleet-wide scan does not deliver every push at once. Defaults to 30. Ignored and overidden as 1 (minute) if --debug is passed.",
+		env.Int("PUSH_SPREAD", 90),
+		"Number of minutes over which the scheduled pushes are spread out for delivery. Each device's push is delayed by a random offset within this window, so a fleet-wide scan does not deliver every push at once. Must be less than CONTROL_PLANE_INTERVAL; clamped if it is not. Defaults to 90. Ignored and overidden as 0 (immediate) if --debug is passed.",
 	)
 	flag.IntVar(
 		&ControlPlaneInterval,
@@ -635,10 +635,11 @@ func main() {
 	// Device inventory is refreshed inside the control-plane scan (single-flight under
 	// the Redis lock), not once per replica at startup -- see director.ScheduledCheckin.
 
-	// Override OnceIn and PushSpread if --debug is passed
+	// Override OnceIn and PushSpread if --debug is passed. Pushes go out immediately in
+	// debug mode -- waiting out a spread window defeats the point of debugging.
 	if debugMode {
 		OnceIn = 2
-		PushSpread = 1
+		PushSpread = 0
 	}
 
 	onceInDuration := (time.Minute * time.Duration(OnceIn))
@@ -646,6 +647,18 @@ func main() {
 	controlPlaneInterval := (time.Minute * time.Duration(ControlPlaneInterval))
 	if debugMode {
 		controlPlaneInterval = time.Minute
+	}
+
+	// The spread window must close before the next scan starts, otherwise a scan runs
+	// while the previous scan's pushes are still pending delivery and re-enqueues them.
+	// Clamp rather than exit: a mistuned knob should not crash-loop the service.
+	if pushSpreadDuration >= controlPlaneInterval {
+		clamped := controlPlaneInterval / 2
+		log.Warnf(
+			"PUSH_SPREAD (%s) must be less than CONTROL_PLANE_INTERVAL (%s); clamping to %s",
+			pushSpreadDuration, controlPlaneInterval, clamped,
+		)
+		pushSpreadDuration = clamped
 	}
 	go director.ScheduledCheckin(ctx, redisClient, PushQueue, onceInDuration, pushSpreadDuration, controlPlaneInterval)
 	go director.ProcessScheduledCheckinQueue(ctx, PushQueue)

--- a/main.go
+++ b/main.go
@@ -103,6 +103,9 @@ var RedisTLS bool
 
 var OnceIn int
 
+// PushSpread is the number of minutes over which scheduled pushes are spread out
+var PushSpread int
+
 // ControlPlaneInterval is the number of minutes between fleet-wide control-plane scans
 var ControlPlaneInterval int
 
@@ -337,6 +340,12 @@ func main() {
 		"once-in",
 		env.Int("ONCE_IN", 60),
 		"Number of minutes to wait before queuing an additional command for any device which already has commands queued. Defaults to 60. Ignored and overidden as 2 (minutes) if --debug is passed.",
+	)
+	flag.IntVar(
+		&PushSpread,
+		"push-spread",
+		env.Int("PUSH_SPREAD", 30),
+		"Number of minutes over which the scheduled pushes are spread out for delivery. Each device's push is delayed by ONCE_IN plus a random offset within this window, so a fleet-wide scan does not deliver every push at once. Defaults to 30. Ignored and overidden as 1 (minute) if --debug is passed.",
 	)
 	flag.IntVar(
 		&ControlPlaneInterval,
@@ -626,17 +635,19 @@ func main() {
 	// Device inventory is refreshed inside the control-plane scan (single-flight under
 	// the Redis lock), not once per replica at startup -- see director.ScheduledCheckin.
 
-	// Override OnceIn if --debug is passed
+	// Override OnceIn and PushSpread if --debug is passed
 	if debugMode {
 		OnceIn = 2
+		PushSpread = 1
 	}
 
 	onceInDuration := (time.Minute * time.Duration(OnceIn))
+	pushSpreadDuration := (time.Minute * time.Duration(PushSpread))
 	controlPlaneInterval := (time.Minute * time.Duration(ControlPlaneInterval))
 	if debugMode {
 		controlPlaneInterval = time.Minute
 	}
-	go director.ScheduledCheckin(ctx, redisClient, PushQueue, onceInDuration, controlPlaneInterval)
+	go director.ScheduledCheckin(ctx, redisClient, PushQueue, onceInDuration, pushSpreadDuration, controlPlaneInterval)
 	go director.ProcessScheduledCheckinQueue(ctx, PushQueue)
 
 	srv := &http.Server{Addr: ":" + port, Handler: r}

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -146,6 +146,13 @@ func OnceIn() int {
 	return flag.Lookup("once-in").Value.(flag.Getter).Get().(int)
 }
 
+// PushSpread is the window, in minutes, over which scheduled pushes are spread out for
+// delivery. Each device's push is delayed by ONCE_IN plus a random offset within this
+// window, so a fleet-wide scan does not deliver every push at the same instant.
+func PushSpread() int {
+	return flag.Lookup("push-spread").Value.(flag.Getter).Get().(int)
+}
+
 func InfoRequestInterval() int {
 	return flag.Lookup("info-request-interval").Value.(flag.Getter).Get().(int)
 }


### PR DESCRIPTION
## Summary

`pushAll` paced its enqueue loop with 500ms sleeps and a 1-minute sleep per chunk of devices (chunk count ~ `ceil(len/60)`), so a control-plane scan could take up to ~1 hour and held the control-plane Redis lock the whole time. A crash mid-scan restarted it from the top.

`pushAll` now loops the due devices once and enqueues each with no sleeps, so the scan finishes in seconds and the lock is held only briefly. Delivery is spread out instead by delaying each message by a random offset in `[0, PUSH_SPREAD)`, which taskq stores as a due time in its Redis zset, so the consumer picks the pushes up gradually.

`PUSH_SPREAD` defaults to **90** minutes, matching the old effective spread. The old pacing pinned the chunk count at ~60 (`ceil(len/60)` devices per chunk), so it spread work over ~68-101 minutes depending on fleet size, not 30 — a 30-minute default would have roughly tripled the peak push rate, and therefore the peak inbound check-in rate, as a side effect of a change billed as making the scan fast.

The delay carries no `ONCE_IN` offset. Per-device cadence is enforced by `NextPush`/`deviceNeedsPush` and by the `OnceInPeriod` dedup name, neither of which depends on `Delay`, so an offset would only make every push a full cadence late.

Two guards keep scans from overlapping with pending deliveries, which was previously unenforced — `NextPush` was only written *after* a push was delivered, and by then the dedup name may have rolled into a new time slot, so a duplicate would not be suppressed:

- `PUSH_SPREAD` must be less than `CONTROL_PLANE_INTERVAL`; it is clamped to half of it with a warning if not. The debug defaults previously violated this.
- `pushAll` reserves `NextPush` at enqueue time for the whole window plus one cadence, in one batched `UPDATE` per 1000 devices. `updateNextPush` still overwrites it with the authoritative time once the push is actually sent.

`OnceInPeriod(period, args...)` sets the dedup name from `msgpack(args) + period + timeSlot` **and** `Delay`; the following `SetDelay` overrides only `Delay`, leaving the name intact, so per-window fleet-wide dedup still holds.

Also drops a duplicated device read: `Find(&dbDevices).Scan(&dbDevices)` re-executed the same statement and overwrote the slice with identical rows, so the scan cost two round trips and two full-table reads for one result. `Find` is kept — it infers the table from the dest and runs the model machinery (soft-delete scoping, `AfterFind`), whereas the trailing `Scan` only worked because `Find` had already built the SQL.

Also adds a `PUSH_SPREAD` flag/env (minutes, default 90, 0 — immediate — under `--debug`), wired like `ONCE_IN`, and drops the now-unused `getDelay` helper and `deviceChunkSlice` chunking. Per-device scan logging drops from Info to Debug: without the pacing sleeps those lines are emitted for the whole fleet within a couple of seconds. Enrollment (`RunInitialTasks`) is untouched — that path is already immediate.

A follow-up PR adds a fleet-wide `RateLimit` on the queue: jitter is a probabilistic spread, not an enforced ceiling, and it does not cover retries.

## Test Plan

New `director/schedule_push_spread_test.go` uses a fake `taskq.Queue` that captures `Add(msg)` and the existing `setupMockDB` sqlmock helper:

- every enqueued message has `Delay` in `[0, PUSH_SPREAD)` and a unique, non-empty dedup `Name`
- delays are actually spread (more than one distinct value across 200 devices)
- a zero spread (debug mode) yields no delay at all
- no devices enqueues nothing
- 200 devices enqueue in well under 5s
- an AST check asserts no `time.Sleep` remains in `pushAll`
- the device scan is stubbed exactly once, so the duplicated read cannot come back
- `NextPush` is reserved for `PUSH_SPREAD + ONCE_IN` and written *before* the first enqueue

`gofmt -l .`, `go vet ./...`, `go build ./...` and `go test ./...` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

