### PR TITLE
Add a fleet-wide rate-limit ceiling on the push queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ These flags enable Declarative Device Management via KMFDDM. DDM requires `mdm-s
 - `-push-new-build` - Re-push profiles if the device's build number changes. (default true) Env: `PUSH_NEW_BUILD`
 - `-once-in int` - Minutes to wait before queuing additional commands for a device with pending commands. (default 60, overridden to 2 if --debug) Env: `ONCE_IN`
 - `-push-spread int` - Minutes over which the scheduled pushes are spread out for delivery. Each device's push is delayed by a random offset within this window, so a fleet-wide scan does not deliver every push at once. Must be less than `control-plane-interval` (clamped to half of it if not), so the window closes before the next scan starts. (default 90, overridden to 0 — immediate — if --debug) Env: `PUSH_SPREAD`
+- `-push-rate-limit int` - Fleet-wide ceiling on device pushes per minute, enforced across all replicas via Redis. This is a safety ceiling for retry storms and misconfiguration, not the normal pacing mechanism — `push-spread` is what sets the operating point. Keep it comfortably above `enrolled devices / push-spread`; a ceiling of 600 over a 90 minute spread paces up to ~54,000 devices per scan. Above that the ceiling becomes the pacer and pushes run past the window. (default 600, 0 disables) Env: `PUSH_RATE_LIMIT`
 - `-info-request-interval int` - Minutes between issuing DeviceInfo, ProfileList, SecurityInfo commands. (default 360) Env: `INFO_REQUEST_INTERVAL`
 
 #### PIN Escrow

--- a/director/push_queue.go
+++ b/director/push_queue.go
@@ -1,0 +1,65 @@
+package director
+
+import (
+	"time"
+
+	"github.com/go-redis/redis_rate/v9"
+	"github.com/vmihailenco/taskq/v3"
+)
+
+// PushQueueName is the taskq queue name for scheduled device pushes.
+const PushQueueName = "pushnotifications"
+
+// PushQueueOptions builds the options for the push queue.
+//
+// perMinute is a fleet-wide ceiling on how fast the consumers may reserve push messages,
+// enforced through Redis, so it holds across every replica rather than per pod. A
+// non-positive value leaves the queue unlimited.
+//
+// This is a ceiling, not a pacing mechanism -- pushAll's delivery spread (PUSH_SPREAD) is
+// what normally keeps the rate low. The limit covers what the spread cannot:
+//
+//   - retries. A failed push is released with backoff and re-reserved; those retries
+//     carry none of the original jitter, so a NanoMDM or APNs outage otherwise means
+//     every push in the window retrying with no throughput bound at all.
+//   - misconfiguration. Nothing else stops a too-small PUSH_SPREAD, or an unusually
+//     large batch of due devices, from saturating the MDM server.
+//
+// Without it the only bound is worker count, which defaults to 32*NumCPU per replica.
+//
+// When messages come due faster than the limit allows, taskq's limiter blocks on
+// reservation (it sleeps for the limiter's RetryAfter) rather than dropping work, so the
+// backlog drains late instead of being lost. It does not compound across scans either:
+// pushAll reserves NextPush for the whole delivery window plus one cadence, so a device
+// whose push is still pending is not due again on the next scan.
+// ImpliedFleetCapacity is how many devices a per-minute ceiling can carry within a spread
+// window. Past this, the rate limit rather than PUSH_SPREAD is what paces delivery, and
+// pushes run past the end of the window. Zero means unlimited.
+func ImpliedFleetCapacity(perMinute int, pushSpread time.Duration) int {
+	if perMinute <= 0 {
+		return 0
+	}
+	return int(float64(perMinute) * pushSpread.Minutes())
+}
+
+// impliedPushRate is the per-minute delivery rate needed to spread count pushes evenly
+// across the window. Compare it against PUSH_RATE_LIMIT.
+func impliedPushRate(count int, pushSpread time.Duration) float64 {
+	if pushSpread <= 0 {
+		return 0
+	}
+	return float64(count) / pushSpread.Minutes()
+}
+
+func PushQueueOptions(name string, redisClient taskq.Redis, perMinute int) *taskq.QueueOptions {
+	opts := &taskq.QueueOptions{
+		Name:  name,
+		Redis: redisClient,
+	}
+
+	if perMinute > 0 {
+		opts.RateLimit = redis_rate.PerMinute(perMinute)
+	}
+
+	return opts
+}

--- a/director/push_queue_test.go
+++ b/director/push_queue_test.go
@@ -1,0 +1,66 @@
+package director
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPushQueueOptionsSetsFleetWideRateLimit(t *testing.T) {
+	opts := PushQueueOptions(PushQueueName, nil, 600)
+
+	assert.Equal(t, PushQueueName, opts.Name)
+
+	require.False(t, opts.RateLimit.IsZero(), "rate limit must be set when perMinute > 0")
+	assert.Equal(t, 600, opts.RateLimit.Rate)
+	assert.Equal(t, time.Minute, opts.RateLimit.Period)
+}
+
+func TestPushQueueOptionsUnlimitedWhenNotPositive(t *testing.T) {
+	for _, perMinute := range []int{0, -1} {
+		opts := PushQueueOptions(PushQueueName, nil, perMinute)
+		assert.True(
+			t, opts.RateLimit.IsZero(),
+			"perMinute %d should leave the queue unlimited", perMinute,
+		)
+	}
+}
+
+// TestPushQueueOptionsRateLimitCoversRetries documents why the limit exists on the queue
+// rather than in pushAll: taskq applies it on the consumer's reservation path, so it
+// bounds retries and any other re-delivery, none of which carry pushAll's jitter.
+func TestPushQueueOptionsRateLimitCoversRetries(t *testing.T) {
+	opts := PushQueueOptions(PushQueueName, nil, 60)
+
+	// A limiter is only constructed by taskq when both a limit and a Redis client are
+	// present, which is what makes the ceiling fleet-wide rather than per replica.
+	require.False(t, opts.RateLimit.IsZero())
+	assert.Nil(t, opts.Redis, "no client passed in this test, so taskq builds no limiter")
+	assert.Nil(t, opts.RateLimiter)
+}
+
+// TestSpreadAndCeilingAreComplementary pins the relationship between the two knobs:
+// PUSH_SPREAD sets the operating point, PUSH_RATE_LIMIT is the ceiling above it. If the
+// implied rate exceeds the ceiling, the ceiling becomes the pacer and the spread stops
+// meaning anything -- which is what the startup and per-scan log lines expose.
+func TestSpreadAndCeilingAreComplementary(t *testing.T) {
+	spread := 90 * time.Minute
+	const perMinute = 600
+
+	capacity := ImpliedFleetCapacity(perMinute, spread)
+	assert.Equal(t, 54000, capacity, "600/min over 90m carries 54k devices")
+
+	// A 10k fleet spread over 90m sits far below the ceiling, leaving headroom for
+	// retries and on-demand pushes.
+	assert.InDelta(t, 111.1, impliedPushRate(10_000, spread), 0.1)
+	assert.Less(t, impliedPushRate(capacity, spread), float64(perMinute+1))
+
+	// Past capacity the ceiling is what paces delivery.
+	assert.Greater(t, impliedPushRate(capacity*2, spread), float64(perMinute))
+
+	// Unlimited and degenerate cases.
+	assert.Zero(t, ImpliedFleetCapacity(0, spread))
+	assert.Zero(t, impliedPushRate(100, 0))
+}

--- a/director/schedule_push.go
+++ b/director/schedule_push.go
@@ -197,7 +197,13 @@ func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn, pushSpread time.Du
 
 	ctx := context.Background()
 	InfoLogger(LogHolder{Message: fmt.Sprintf("commands will only be queued for an individual device every %s at maximum", onceIn)})
-	InfoLogger(LogHolder{Message: fmt.Sprintf("%d pushes will be spread over %s", len(devices), pushSpread)})
+	// The implied rate is the number to compare against PUSH_RATE_LIMIT: if it exceeds
+	// the ceiling, the limiter -- not this spread -- is what paces delivery, and pushes
+	// will run past the window.
+	InfoLogger(LogHolder{Message: fmt.Sprintf(
+		"%d pushes will be spread over %s (~%.0f/min)",
+		len(devices), pushSpread, impliedPushRate(len(devices), pushSpread),
+	)})
 
 	// Reserve before enqueuing: the messages below are not delivered until up to
 	// pushSpread from now, and NextPush is otherwise only written once a push has

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/bsm/redislock v0.7.2
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/go-redis/redis/v8 v8.11.5
+	github.com/go-redis/redis_rate/v9 v9.1.2
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/groob/plist v0.0.0-20220217120414-63fa881b19a5
@@ -32,7 +33,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/go-redis/redis_rate/v9 v9.1.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/mdmdirector/mdmdirector/types"
 	"github.com/mdmdirector/mdmdirector/utils"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/vmihailenco/taskq/v3"
 	"github.com/vmihailenco/taskq/v3/redisq"
 
 	"github.com/micromdm/go4/env"
@@ -105,6 +104,9 @@ var OnceIn int
 
 // PushSpread is the number of minutes over which scheduled pushes are spread out
 var PushSpread int
+
+// PushRateLimit is the fleet-wide ceiling on pushes per minute (0 disables it)
+var PushRateLimit int
 
 // ControlPlaneInterval is the number of minutes between fleet-wide control-plane scans
 var ControlPlaneInterval int
@@ -346,6 +348,12 @@ func main() {
 		"push-spread",
 		env.Int("PUSH_SPREAD", 90),
 		"Number of minutes over which the scheduled pushes are spread out for delivery. Each device's push is delayed by a random offset within this window, so a fleet-wide scan does not deliver every push at once. Must be less than CONTROL_PLANE_INTERVAL; clamped if it is not. Defaults to 90. Ignored and overidden as 0 (immediate) if --debug is passed.",
+	)
+	flag.IntVar(
+		&PushRateLimit,
+		"push-rate-limit",
+		env.Int("PUSH_RATE_LIMIT", 600),
+		"Fleet-wide ceiling on how many device pushes may be sent per minute, enforced across all replicas via Redis. A safety ceiling for retry storms and misconfiguration, not the normal pacing mechanism -- that is PUSH_SPREAD. Should stay comfortably above (enrolled devices / PUSH_SPREAD). Defaults to 600. Set to 0 to disable.",
 	)
 	flag.IntVar(
 		&ControlPlaneInterval,
@@ -617,10 +625,9 @@ func main() {
 	// One shared go-redis client backs both the taskq queue and the control-plane lock.
 	redisClient := director.RedisClient()
 
-	var PushQueue = QueueFactory.RegisterQueue(&taskq.QueueOptions{
-		Name:  "pushnotifications",
-		Redis: redisClient, // go-redis client
-	})
+	var PushQueue = QueueFactory.RegisterQueue(
+		director.PushQueueOptions(director.PushQueueName, redisClient, PushRateLimit),
+	)
 
 	if utils.Prometheus() {
 		director.PollGauges()
@@ -660,6 +667,15 @@ func main() {
 		)
 		pushSpreadDuration = clamped
 	}
+	// Make the spread/ceiling relationship visible: PUSH_SPREAD sets the operating point,
+	// PUSH_RATE_LIMIT is the ceiling. Past this fleet size the ceiling becomes the pacer.
+	if capacity := director.ImpliedFleetCapacity(PushRateLimit, pushSpreadDuration); capacity > 0 {
+		log.Infof(
+			"PUSH_RATE_LIMIT of %d/min over a PUSH_SPREAD of %s paces up to ~%d devices per scan; above that the rate limit sets the pace and pushes run past the window",
+			PushRateLimit, pushSpreadDuration, capacity,
+		)
+	}
+
 	go director.ScheduledCheckin(ctx, redisClient, PushQueue, onceInDuration, pushSpreadDuration, controlPlaneInterval)
 	go director.ProcessScheduledCheckinQueue(ctx, PushQueue)
 

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -153,6 +153,12 @@ func PushSpread() int {
 	return flag.Lookup("push-spread").Value.(flag.Getter).Get().(int)
 }
 
+// PushRateLimit is the fleet-wide ceiling on device pushes per minute, enforced across
+// replicas by the taskq consumer. 0 means unlimited.
+func PushRateLimit() int {
+	return flag.Lookup("push-rate-limit").Value.(flag.Getter).Get().(int)
+}
+
 func InfoRequestInterval() int {
 	return flag.Lookup("info-request-interval").Value.(flag.Getter).Get().(int)
 }


### PR DESCRIPTION
## Summary

`PUSH_SPREAD` (#160) paces the pushes a scan schedules, but it is a probabilistic spread, not an enforced bound, and it does not cover re-delivery. A failed push is released with backoff and re-reserved carrying none of the original jitter, so a NanoMDM or APNs outage means every push in the window retrying with no throughput bound at all. Until now the only bound anywhere was worker count, which defaults to `32*NumCPU` **per replica** (`taskq/queue.go:87`) — `QueueOptions` set no `RateLimit` and no `WorkerLimit`.

`PUSH_RATE_LIMIT` (per minute, default 600, `0` disables) sets taskq's `RateLimit` on the push queue. taskq enforces it on the consumer's reservation path via Redis (`consumer.go:417`, `consumer.go:886`), so it is fleet-wide rather than per pod, it covers retries, and it stays effective when config changes — unlike the spread, which is committed to zset due-times the moment a scan runs.

**The two knobs are complementary, not redundant.** The spread sets the operating point; the limit is the ceiling above it:

| | 10k fleet, `PUSH_SPREAD=90` | Ceiling `PUSH_RATE_LIMIT=600` |
|---|---|---|
| Push rate | ~111/min | 600/min |
| Resulting check-in responses | ~444/min | ~2,400/min |
| Window occupied | 90 min | ~17 min, then idle |

With only a ceiling, the fleet is pushed as fast as the ceiling permits: the system runs *pinned at its own limit* for 17 minutes with zero headroom for retries or on-demand pushes, then idles. A ceiling set low enough to serve as pacing would throttle retries too, which is exactly what it exists to absorb. And the limiter bounds message reservation, not consequences — each push produces a device check-in and four command responses a few seconds later, and none of that inbound traffic is rate-limited at all, so flattening the push rate is the only lever on it.

Because that relationship is easy to get wrong, it is now visible rather than implicit: startup logs the fleet size the ceiling can pace within the window (`600/min × 90m ≈ 54,000 devices`), and each scan logs the rate it implies. When the implied rate exceeds the ceiling, the limiter rather than the spread is what paces delivery, and pushes run past the window.

Degradation is safe: when messages come due faster than the limit allows, taskq's limiter sleeps for the limiter's `RetryAfter` rather than dropping work, so the backlog drains late instead of being lost. It does not compound across scans either — `pushAll` reserves `NextPush` for the whole window plus one cadence, so a device whose push is still pending is not due again on the next scan.

Default 600/min is ~6x the throughput the pre-#160 pacing actually achieved (~1.7/s at 10k devices), so it is not a behavioural change for existing fleets.

Depends on: #160

## Test Plan

New `director/push_queue_test.go`:

- `PushQueueOptions` sets `RateLimit` to `redis_rate.PerMinute(n)` for `n > 0`
- `0` and negative values leave the queue unlimited
- `ImpliedFleetCapacity` / `impliedPushRate` agree on the crossover point where the ceiling becomes the pacer (600/min over 90m ⇒ 54k devices; 10k ⇒ ~111/min), plus the unlimited and zero-spread cases

Queue construction moved out of `main.go` into `director.PushQueueOptions` so it is testable at all.

`gofmt -l .`, `go vet ./...`, `go build ./...` and `go test ./...` are clean. `go mod tidy` promotes `redis_rate/v9` from indirect to direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)