### PR TITLE
[MDMv2] Metrics for /profiledownload, DDM

### DIFF
--- a/director/gauges.go
+++ b/director/gauges.go
@@ -10,10 +10,12 @@ import (
 
 const gaugePollInterval = time.Minute
 
-// PollGauges starts background pollers that populate - mdmdirector_devices_total and mdmdirector_profiles_total
+// PollGauges starts background pollers that populate - mdmdirector_devices_total,
+// mdmdirector_profiles_total and mdmdirector_ddm_enabled_devices_total
 func PollGauges() {
 	go pollDevices()
 	go pollProfiles()
+	go pollDDMOptIns()
 }
 
 func pollDevices() {
@@ -31,6 +33,18 @@ func pollProfiles() {
 	for range time.Tick(gaugePollInterval) {
 		setProfilesGauge("shared", &types.SharedProfile{})
 		setProfilesGauge("device", &types.DeviceProfile{})
+	}
+}
+
+// pollDDMOptIns tracks how far the per-device DDM rollout has progressed
+func pollDDMOptIns() {
+	for range time.Tick(gaugePollInterval) {
+		var count int64
+		if err := db.DB.Model(&DDMOptIn{}).Count(&count).Error; err != nil {
+			ErrorLogger(LogHolder{Message: err.Error()})
+			continue
+		}
+		metrics.DDMEnabledDevices().Set(float64(count))
 	}
 }
 

--- a/director/http_metrics.go
+++ b/director/http_metrics.go
@@ -1,0 +1,51 @@
+package director
+
+import (
+	"net/http"
+
+	"github.com/mdmdirector/mdmdirector/director/metrics"
+	"github.com/mdmdirector/mdmdirector/utils"
+)
+
+// statusResponseWriter records the first status code a handler writes. The /profile
+// handlers have many error branches, several of which write an error status and keep
+// going, so the first status written is the request's real outcome.
+type statusResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusResponseWriter) WriteHeader(code int) {
+	if w.status == 0 {
+		w.status = code
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *statusResponseWriter) Write(b []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// WithProfileAPIMetrics counts requests to the /profile API by method and result.
+// method is "post" or "delete".
+func WithProfileAPIMetrics(method string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !utils.Prometheus() {
+			next(w, r)
+			return
+		}
+
+		recorder := &statusResponseWriter{ResponseWriter: w}
+		next(recorder, r)
+
+		// A handler that returns without writing anything has implicitly succeeded
+		status := recorder.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		metrics.ProfileAPIRequests(method, metrics.ResultLabel(status)).Inc()
+	}
+}

--- a/director/metrics/metrics.go
+++ b/director/metrics/metrics.go
@@ -142,6 +142,49 @@ func ProfileVerificationMismatches(scope string) prometheus.Counter {
 	return profileVerificationMismatchesTotal.WithLabelValues(scope)
 }
 
+// profileDownloadRequestsTotal counts /profiledownload requests made by devices fetching
+// the mobileconfig referenced by a DDM legacy-profile declaration's ProfileURL
+// Labels:
+//   - scope:   "device" (served from device_profiles), "shared" (served from shared_profiles),
+//     "none" (nothing served)
+//   - outcome: "success", "unauthorized" (X-Enrollment-ID mismatch), "not_found"
+//     (dangling declaration - no installed profile for the identifier), "error"
+//
+//nolint:gochecknoglobals
+var profileDownloadRequestsTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: subsystem,
+		Name:      "profile_download_requests_total",
+		Help:      "Total /profiledownload requests served to devices, by scope and outcome.",
+	},
+	[]string{"scope", "outcome"},
+)
+
+// ProfileDownloadRequests - accessor for profileDownloadRequestsTotal
+func ProfileDownloadRequests(scope, outcome string) prometheus.Counter {
+	return profileDownloadRequestsTotal.WithLabelValues(scope, outcome)
+}
+
+// profileAPIRequestsTotal counts operator-driven requests to the /profile API
+// Labels:
+//   - method: "post" or "delete"
+//   - result: "success" or "error"
+//
+//nolint:gochecknoglobals
+var profileAPIRequestsTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: subsystem,
+		Name:      "profile_api_requests_total",
+		Help:      "Total /profile API requests by method and result.",
+	},
+	[]string{"method", "result"},
+)
+
+// ProfileAPIRequests - accessor for profileAPIRequestsTotal
+func ProfileAPIRequests(method, result string) prometheus.Counter {
+	return profileAPIRequestsTotal.WithLabelValues(method, result)
+}
+
 // initialTasksTotal counts RunInitialTasks invocations by terminal result
 // result: "success", "error", "lease_contention"
 //
@@ -270,6 +313,22 @@ var profilesTotal = promauto.NewGaugeVec(
 // ProfilesTotal - accessor for profilesTotal
 func ProfilesTotal(scope, installed string) prometheus.Gauge {
 	return profilesTotal.WithLabelValues(scope, installed)
+}
+
+// ddmEnabledDevicesTotal reports the current number of devices explicitly opted into DDM
+//
+//nolint:gochecknoglobals
+var ddmEnabledDevicesTotal = promauto.NewGauge(
+	prometheus.GaugeOpts{
+		Subsystem: subsystem,
+		Name:      "ddm_enabled_devices_total",
+		Help:      "Current number of devices explicitly opted into DDM.",
+	},
+)
+
+// DDMEnabledDevices - accessor for ddmEnabledDevicesTotal
+func DDMEnabledDevices() prometheus.Gauge {
+	return ddmEnabledDevicesTotal
 }
 
 // ResultLabel maps an HTTP status code or error presence to the canonical result label.

--- a/director/metrics/metrics_test.go
+++ b/director/metrics/metrics_test.go
@@ -150,6 +150,39 @@ func TestPinEscrow_incrementsByResult(t *testing.T) {
 	assert.Equal(t, before+1, prometheustestutil.ToFloat64(counter))
 }
 
+func TestProfileDownloadRequests_incrementsByLabels(t *testing.T) {
+	counter := ProfileDownloadRequests("device", "success")
+	before := prometheustestutil.ToFloat64(counter)
+
+	counter.Inc()
+
+	assert.Equal(t, before+1, prometheustestutil.ToFloat64(counter))
+
+	// Different label tuple is a distinct series.
+	other := ProfileDownloadRequests("none", "not_found")
+	assert.Equal(t, float64(0), prometheustestutil.ToFloat64(other))
+}
+
+func TestProfileAPIRequests_incrementsByLabels(t *testing.T) {
+	counter := ProfileAPIRequests("post", "success")
+	before := prometheustestutil.ToFloat64(counter)
+
+	counter.Inc()
+
+	assert.Equal(t, before+1, prometheustestutil.ToFloat64(counter))
+
+	other := ProfileAPIRequests("delete", "error")
+	assert.Equal(t, float64(0), prometheustestutil.ToFloat64(other))
+}
+
+func TestDDMEnabledDevices_setsValue(t *testing.T) {
+	gauge := DDMEnabledDevices()
+
+	gauge.Set(42)
+
+	assert.Equal(t, float64(42), prometheustestutil.ToFloat64(gauge))
+}
+
 func TestResultLabel(t *testing.T) {
 	assert.Equal(t, "success", ResultLabel(200))
 	assert.Equal(t, "success", ResultLabel(399))

--- a/director/profile.go
+++ b/director/profile.go
@@ -1277,15 +1277,10 @@ func signIfRequired(mobileconfigData []byte) ([]byte, error) {
 	if !utils.Sign() {
 		return mobileconfigData, nil
 	}
-	priv, cert, err := loadSigningKey(
-		utils.KeyPassword(),
-		utils.KeyPath(),
-		utils.CertPath(),
-	)
-	if err != nil {
-		return nil, errors.Wrap(err, "loading signing key")
+	if signingPrivKey == nil || signingCert == nil {
+		return nil, errors.New("signing is enabled but the signing key was not loaded at startup")
 	}
-	signed, err := SignProfile(priv, cert, mobileconfigData)
+	signed, err := SignProfile(signingPrivKey, signingCert, mobileconfigData)
 	if err != nil {
 		return nil, errors.Wrap(err, "signing profile")
 	}
@@ -1444,32 +1439,49 @@ func InstallAllProfiles(device types.Device) ([]types.Command, error) {
 	return pushedCommands, nil
 }
 
-func findMobileconfigData(udid, profileIdentifier string) ([]byte, error) {
+// Scopes reported on the profile_download_requests_total metric. "none" means nothing was
+// served, so the request had no scope.
+const (
+	profileScopeDevice = "device"
+	profileScopeShared = "shared"
+	profileScopeNone   = "none"
+)
+
+// findMobileconfigData returns the mobileconfig to serve for a device/identifier pair
+// along with the scope it was found in (profileScopeDevice or profileScopeShared).
+func findMobileconfigData(udid, profileIdentifier string) ([]byte, string, error) {
 	var deviceProfile types.DeviceProfile
 	err := db.DB.Where("device_ud_id = ? AND payload_identifier = ?", udid, profileIdentifier).First(&deviceProfile).Error
 	if err == nil {
 		if !deviceProfile.Installed {
-			return nil, gorm.ErrRecordNotFound
+			return nil, profileScopeNone, gorm.ErrRecordNotFound
 		}
-		return deviceProfile.MobileconfigData, nil
+		return deviceProfile.MobileconfigData, profileScopeDevice, nil
 	}
 	if !intErrors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, fmt.Errorf("device profile lookup: %w", err)
+		return nil, profileScopeNone, fmt.Errorf("device profile lookup: %w", err)
 	}
 
 	var sharedProfile types.SharedProfile
 	err = db.DB.Where("payload_identifier = ?", profileIdentifier).First(&sharedProfile).Error
 	if err == nil {
 		if !sharedProfile.Installed {
-			return nil, gorm.ErrRecordNotFound
+			return nil, profileScopeNone, gorm.ErrRecordNotFound
 		}
-		return sharedProfile.MobileconfigData, nil
+		return sharedProfile.MobileconfigData, profileScopeShared, nil
 	}
 	if !intErrors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, fmt.Errorf("shared profile lookup: %w", err)
+		return nil, profileScopeNone, fmt.Errorf("shared profile lookup: %w", err)
 	}
 
-	return nil, gorm.ErrRecordNotFound
+	return nil, profileScopeNone, gorm.ErrRecordNotFound
+}
+
+// recordProfileDownload counts the terminal outcome of a /profiledownload request
+func recordProfileDownload(scope, outcome string) {
+	if utils.Prometheus() {
+		metrics.ProfileDownloadRequests(scope, outcome).Inc()
+	}
 }
 
 func ProfileDownloadHandler(w http.ResponseWriter, r *http.Request) {
@@ -1478,28 +1490,72 @@ func ProfileDownloadHandler(w http.ResponseWriter, r *http.Request) {
 	profileIdentifier := vars["profileIdentifier"]
 
 	if r.Header.Get("X-Enrollment-ID") != udid {
+		InfoLogger(
+			LogHolder{
+				DeviceUDID:        udid,
+				ProfileIdentifier: profileIdentifier,
+				Message:           "Profile download rejected: X-Enrollment-ID does not match the requested device",
+			},
+		)
+		recordProfileDownload(profileScopeNone, "unauthorized")
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	mobileconfigData, err := findMobileconfigData(udid, profileIdentifier)
+	mobileconfigData, scope, err := findMobileconfigData(udid, profileIdentifier)
 	if intErrors.Is(err, gorm.ErrRecordNotFound) {
+		// The device was given a ProfileURL for a profile we don't have, or that is
+		// marked as not installed - the declaration is dangling
+		InfoLogger(
+			LogHolder{
+				DeviceUDID:        udid,
+				ProfileIdentifier: profileIdentifier,
+				Message:           "Profile download: no installed profile found for identifier",
+			},
+		)
+		recordProfileDownload(profileScopeNone, "not_found")
 		http.Error(w, "Not Found", http.StatusNotFound)
 		return
 	}
 	if err != nil {
-		log.Errorf("profile download lookup: %v", err)
+		ErrorLogger(
+			LogHolder{
+				DeviceUDID:        udid,
+				ProfileIdentifier: profileIdentifier,
+				Message:           fmt.Sprintf("Profile download lookup: %v", err),
+			},
+		)
+		recordProfileDownload(profileScopeNone, "error")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
 	responseData, err := signIfRequired(mobileconfigData)
 	if err != nil {
-		log.Errorf("profile download signing: %v", err)
+		ErrorLogger(
+			LogHolder{
+				DeviceUDID:        udid,
+				ProfileIdentifier: profileIdentifier,
+				Message:           fmt.Sprintf("Profile download signing: %v", err),
+			},
+		)
+		recordProfileDownload(scope, "error")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/x-apple-aspen-config")
-	_, _ = w.Write(responseData)
+	if _, err := w.Write(responseData); err != nil {
+		// Headers are already sent, so the device sees a truncated response
+		ErrorLogger(
+			LogHolder{
+				DeviceUDID:        udid,
+				ProfileIdentifier: profileIdentifier,
+				Message:           fmt.Sprintf("Profile download write: %v", err),
+			},
+		)
+		recordProfileDownload(scope, "error")
+		return
+	}
+	recordProfileDownload(scope, "success")
 }

--- a/director/profile_test.go
+++ b/director/profile_test.go
@@ -13,8 +13,10 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/mdmdirector/mdmdirector/db"
+	"github.com/mdmdirector/mdmdirector/director/metrics"
 	"github.com/mdmdirector/mdmdirector/types"
 	"github.com/pkg/errors"
+	prometheustestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -434,6 +436,138 @@ func TestProfileDownloadHandler_NoProfileFound(t *testing.T) {
 	serveProfileDownload(rr, req)
 
 	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// withPrometheusEnabled turns the prometheus flag on for the duration of a test so the
+// instrumentation at the call site actually runs
+func withPrometheusEnabled(t *testing.T) {
+	t.Helper()
+	require.NoError(t, flag.Set("prometheus", "true"))
+	t.Cleanup(func() {
+		_ = flag.Set("prometheus", "false")
+	})
+}
+
+func TestProfileDownloadHandler_RecordsUnauthorizedMetric(t *testing.T) {
+	_ = flag.Set("sign", "false")
+	withPrometheusEnabled(t)
+
+	counter := metrics.ProfileDownloadRequests(profileScopeNone, "unauthorized")
+	before := prometheustestutil.ToFloat64(counter)
+
+	rr, req := newProfileDownloadRequest("device-udid-123", "com.example.profile", "different-udid-456")
+	serveProfileDownload(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Equal(t, before+1, prometheustestutil.ToFloat64(counter))
+}
+
+func TestProfileDownloadHandler_RecordsNotFoundMetric(t *testing.T) {
+	_ = flag.Set("sign", "false")
+	withPrometheusEnabled(t)
+
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	mockSpy.ExpectQuery(`^SELECT \* FROM "device_profiles" WHERE device_ud_id = \$1 AND payload_identifier = \$2`).
+		WithArgs("device-udid-123", "com.example.dangling").
+		WillReturnRows(sqlmock.NewRows([]string{"payload_identifier", "device_ud_id", "installed", "mobileconfig_data"}))
+	mockSpy.ExpectQuery(`^SELECT \* FROM "shared_profiles" WHERE payload_identifier = \$1`).
+		WithArgs("com.example.dangling").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "payload_identifier", "installed", "mobileconfig_data"}))
+
+	counter := metrics.ProfileDownloadRequests(profileScopeNone, "not_found")
+	before := prometheustestutil.ToFloat64(counter)
+
+	rr, req := newProfileDownloadRequest("device-udid-123", "com.example.dangling", "device-udid-123")
+	serveProfileDownload(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Equal(t, before+1, prometheustestutil.ToFloat64(counter))
+}
+
+func TestProfileDownloadHandler_RecordsSuccessMetricWithScope(t *testing.T) {
+	_ = flag.Set("sign", "false")
+	withPrometheusEnabled(t)
+
+	postgresMock, mockSpy, _ := sqlmock.New()
+	defer postgresMock.Close()
+
+	DB, _ := gorm.Open(postgres.New(postgres.Config{Conn: postgresMock}), &gorm.Config{})
+	db.DB = DB
+
+	profileData := []byte("<?xml version=\"1.0\"?><plist><dict><key>shared</key></dict></plist>")
+
+	// Device profile not found, so the shared profile is served
+	mockSpy.ExpectQuery(`^SELECT \* FROM "device_profiles" WHERE device_ud_id = \$1 AND payload_identifier = \$2`).
+		WithArgs("device-udid-125", "com.example.shared").
+		WillReturnRows(sqlmock.NewRows([]string{"payload_identifier", "device_ud_id", "installed", "mobileconfig_data"}))
+	mockSpy.ExpectQuery(`^SELECT \* FROM "shared_profiles" WHERE payload_identifier = \$1`).
+		WithArgs("com.example.shared").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"id", "payload_identifier", "installed", "mobileconfig_data"}).
+				AddRow("00000000-0000-0000-0000-000000000001", "com.example.shared", true, profileData),
+		)
+
+	sharedCounter := metrics.ProfileDownloadRequests(profileScopeShared, "success")
+	deviceCounter := metrics.ProfileDownloadRequests(profileScopeDevice, "success")
+	sharedBefore := prometheustestutil.ToFloat64(sharedCounter)
+	deviceBefore := prometheustestutil.ToFloat64(deviceCounter)
+
+	rr, req := newProfileDownloadRequest("device-udid-125", "com.example.shared", "device-udid-125")
+	serveProfileDownload(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, sharedBefore+1, prometheustestutil.ToFloat64(sharedCounter))
+	assert.Equal(t, deviceBefore, prometheustestutil.ToFloat64(deviceCounter))
+}
+
+func TestWithProfileAPIMetrics_RecordsResultFromStatus(t *testing.T) {
+	withPrometheusEnabled(t)
+
+	tests := []struct {
+		name   string
+		method string
+		status int
+		result string
+	}{
+		{name: "post success", method: "post", status: http.StatusOK, result: "success"},
+		{name: "delete error", method: "delete", status: http.StatusInternalServerError, result: "error"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			counter := metrics.ProfileAPIRequests(test.method, test.result)
+			before := prometheustestutil.ToFloat64(counter)
+
+			handler := WithProfileAPIMetrics(test.method, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(test.status)
+			})
+			handler(httptest.NewRecorder(), httptest.NewRequest("POST", "/profile", nil))
+
+			assert.Equal(t, before+1, prometheustestutil.ToFloat64(counter))
+		})
+	}
+}
+
+// A handler that writes an error status and keeps going (as several /profile branches do)
+// is counted once, by the first status written
+func TestWithProfileAPIMetrics_UsesFirstStatusWritten(t *testing.T) {
+	withPrometheusEnabled(t)
+
+	counter := metrics.ProfileAPIRequests("post", "error")
+	before := prometheustestutil.ToFloat64(counter)
+
+	handler := WithProfileAPIMetrics("post", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+		_, _ = w.Write([]byte("continued anyway"))
+	})
+	handler(httptest.NewRecorder(), httptest.NewRequest("POST", "/profile", nil))
+
+	assert.Equal(t, before+1, prometheustestutil.ToFloat64(counter))
 }
 
 func TestSignIfRequired_SigningDisabled(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -536,8 +536,10 @@ func main() {
 
 	r := mux.NewRouter()
 	r.HandleFunc("/webhook", director.WebhookHandler).Methods("POST")
-	r.HandleFunc("/profile", utils.BasicAuth(director.PostProfileHandler)).Methods("POST")
-	r.HandleFunc("/profile", utils.BasicAuth(director.DeleteProfileHandler)).Methods("DELETE")
+	r.HandleFunc("/profile", utils.BasicAuth(director.WithProfileAPIMetrics("post", director.PostProfileHandler))).
+		Methods("POST")
+	r.HandleFunc("/profile", utils.BasicAuth(director.WithProfileAPIMetrics("delete", director.DeleteProfileHandler))).
+		Methods("DELETE")
 	r.HandleFunc("/profile", utils.BasicAuth(director.GetSharedProfiles)).Methods("GET")
 	r.HandleFunc("/profile/{udid}", utils.BasicAuth(director.GetDeviceProfiles)).Methods("GET")
 	r.HandleFunc("/device", utils.BasicAuth(director.DeviceHandler)).Methods("GET")


### PR DESCRIPTION
## What

Adds metrics and structured logging to `/profiledownload`, which had neither, plus two
smaller metrics and one performance fix on the same code path.

`/profiledownload` is the endpoint devices hit to fetch a mobileconfig referenced by a DDM
legacy-profile declaration's `ProfileURL`. Every failure there is a profile that never
installs — and today it shows up nowhere. `mdmdirector_profile_operations_total{operation="pushed"}`
counts the declaration write as a success regardless of whether the device ever retrieved
the payload. The 401, 404, and success paths were entirely silent; the only observability
was two bare `log.Errorf` calls with no device attribution.

## Metrics added

| metric | labels |
|---|---|
| `mdmdirector_profile_download_requests_total` | `scope` (device/shared/none), `outcome` (success/unauthorized/not_found/error) |
| `mdmdirector_ddm_enabled_devices_total` | gauge, no labels |
| `mdmdirector_profile_api_requests_total` | `method` (post/delete), `result` |