### PR TITLE
[MDMv2] Stop storing NanoMDM user-channel enrollments as devices

### DIFF
--- a/director/background_tasks.go
+++ b/director/background_tasks.go
@@ -162,17 +162,28 @@ func FetchDevicesFromMDM() {
 	log.Info("Finished fetching devices from MicroMDM...")
 }
 
-// fetchDevicesFromNanoMDM fetches all enrollments from NanoMDM and upserts them into the DB
+// fetchDevicesFromNanoMDM fetches the device-channel enrollments from NanoMDM and
+// upserts them into the DB. User-channel enrollments are deliberately excluded: they
+// describe a user account signed in on a Mac, not a device.
 func fetchDevicesFromNanoMDM(nanoClient *mdm.NanoMDMClient) {
-	resp, err := nanoClient.GetAllEnrollments(nil)
+	filter := &mdm.EnrollmentFilter{Types: mdm.DeviceChannelEnrollmentTypes}
+	resp, err := nanoClient.QueryEnrollments(filter, nil)
 	if err != nil {
 		ErrorLogger(LogHolder{Message: errors.Wrap(err, "FetchDevicesFromMDM via NanoMDM").Error()})
 		return
 	}
 
 	var devices []types.Device
+	var skippedUserChannel int
 	for _, enrollment := range resp.Enrollments {
 		if enrollment.ID == "" {
+			continue
+		}
+
+		// Belt and braces alongside the type filter above: if the server ever returns a
+		// user-channel enrollment regardless, its ID shape still identifies it.
+		if mdm.IsUserChannelEnrollmentID(enrollment.ID) {
+			skippedUserChannel++
 			continue
 		}
 
@@ -191,6 +202,12 @@ func fetchDevicesFromNanoMDM(nanoClient *mdm.NanoMDMClient) {
 		}
 
 		devices = append(devices, device)
+	}
+
+	if skippedUserChannel > 0 {
+		log.WithFields(log.Fields{
+			"skipped_user_channel_enrollments": skippedUserChannel,
+		}).Info("Skipped user-channel enrollments returned by NanoMDM")
 	}
 
 	// Batch upsert

--- a/director/schedule_push.go
+++ b/director/schedule_push.go
@@ -171,7 +171,9 @@ func pushAll(pushQueue taskq.Queue, task *taskq.Task, onceIn time.Duration) erro
 
 	DelaySeconds := getDelay() // nolint:staticcheck
 
-	err := db.DB.Find(&dbDevices).Scan(&dbDevices).Error
+	// Exclude user-channel enrollments (see fetchDevicesFromNanoMDM). They are not
+	// devices, so the device-channel info commands never come back for them.
+	err := db.DB.Where("ud_id NOT LIKE ?", "%:%").Find(&dbDevices).Scan(&dbDevices).Error
 	if err != nil {
 		return errors.Wrap(err, "PushAll: Scan devices")
 	}

--- a/mdm/enrollment_types_test.go
+++ b/mdm/enrollment_types_test.go
@@ -1,0 +1,73 @@
+package mdm
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsUserChannelEnrollmentID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{
+			name: "device UDID is not a user channel",
+			id:   "6F1A0F12-A055-5EF0-B534-E0A6D0770BA5",
+			want: false,
+		},
+		{
+			name: "device UDID joined to a user ID is a user channel",
+			id:   "6F1A0F12-A055-5EF0-B534-E0A6D0770BA5:E21CD48A-064F-434D-BB05-9E195044FB55",
+			want: true,
+		},
+		{
+			name: "empty ID is not a user channel",
+			id:   "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsUserChannelEnrollmentID(tt.id))
+		})
+	}
+}
+
+// TestDeviceChannelEnrollmentTypesFilter asserts the device-channel type allowlist is
+// serialised into the enrollment query body, so the server can exclude user channels
+// before they reach us.
+func TestDeviceChannelEnrollmentTypesFilter(t *testing.T) {
+	assert.NotContains(t, DeviceChannelEnrollmentTypes, EnrollmentTypeUser)
+	assert.NotContains(t, DeviceChannelEnrollmentTypes, EnrollmentTypeUserEnrollment)
+	assert.NotContains(t, DeviceChannelEnrollmentTypes, EnrollmentTypeSharedIPad)
+
+	var capturedFilter *EnrollmentFilter
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody EnrollmentQueryRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&reqBody))
+		capturedFilter = reqBody.Filter
+
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(EnrollmentsResponse{})
+	}))
+	defer server.Close()
+
+	client := createTestClient(server.URL, "test-key")
+
+	_, err := client.QueryEnrollments(&EnrollmentFilter{Types: DeviceChannelEnrollmentTypes}, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, capturedFilter)
+	assert.Equal(
+		t,
+		[]string{EnrollmentTypeDevice, EnrollmentTypeUserEnrollmentDevice},
+		capturedFilter.Types,
+	)
+}

--- a/mdm/types.go
+++ b/mdm/types.go
@@ -1,5 +1,7 @@
 package mdm
 
+import "strings"
+
 // EnrollmentStatus is the per-enrollment ID results of Push or Enqueue APIs
 type EnrollmentStatus struct {
 	PushError    string `json:"push_error,omitempty"`
@@ -110,6 +112,35 @@ type Enrollment struct {
 	Enabled          bool              `json:"enabled"`
 	TokenUpdateTally int               `json:"token_update_tally,omitempty"`
 	LastSeen         string            `json:"last_seen,omitempty"`
+}
+
+// Enrollment types as reported by NanoMDM. "Device" and "User Enrollment (Device)" are
+// device channels (one physical device); the rest are user channels, which represent a
+// user account signed in on a device rather than a device of their own.
+const (
+	EnrollmentTypeDevice               = "Device"
+	EnrollmentTypeUser                 = "User"
+	EnrollmentTypeUserEnrollmentDevice = "User Enrollment (Device)"
+	EnrollmentTypeUserEnrollment       = "User Enrollment"
+	EnrollmentTypeSharedIPad           = "Shared iPad"
+)
+
+// DeviceChannelEnrollmentTypes are the enrollment types that correspond to a physical
+// device, suitable for an EnrollmentFilter when only devices are wanted.
+var DeviceChannelEnrollmentTypes = []string{
+	EnrollmentTypeDevice,
+	EnrollmentTypeUserEnrollmentDevice,
+}
+
+// userChannelIDSeparator separates the device UDID from the user ID in the enrollment ID
+// NanoMDM assigns to a user channel, e.g.
+// "6F1A0F12-A055-5EF0-B534-E0A6D0770BA5:E21CD48A-064F-434D-BB05-9E195044FB55".
+const userChannelIDSeparator = ":"
+
+// IsUserChannelEnrollmentID reports whether an enrollment ID belongs to a user channel
+// rather than a device. Device UDIDs never contain the separator.
+func IsUserChannelEnrollmentID(id string) bool {
+	return strings.Contains(id, userChannelIDSeparator)
 }
 
 // EnrollmentFilter is the filter for querying enrollments


### PR DESCRIPTION
## Problem

The `devices` table had duplicate rows for some serial numbers — the same serial
appearing twice under two different `ud_id` values:

 serial_number |                                   ud_id
---------------+---------------------------------------------------------------------------
 M4YHXXXXX    | 6F1A0F12-XXXX-5EF0-XXXX-E0AXXX770BA5:E21CD48A-XXXX-434D-XXXX-9E195044FB55
 M4YHXXXXX    | 6F1A0F12-XXXX-5EF0-XXXX-E0AXXX770BA5

The `:`-joined row is not a device. It is a NanoMDM **user-channel** enrollment ID,
formatted `<device UDID>:<user UUID>` — the same physical Mac, but the MDM channel for a
signed-in user account rather than the machine.

## Root cause

`fetchDevicesFromNanoMDM` called `GetAllEnrollments(nil)` — no filter. NanoMDM's
`/v1/enrollments/query` returns every enrollment type in one list (`Device`, `User`,
`User Enrollment (Device)`, `User Enrollment`, `Shared iPad`), and it reports the parent
device's serial number against user-channel enrollments. The sync took each enrollment ID
at face value as a device UDID, so every user channel became an extra `devices` row
sharing a real device's serial.

mdmdirector has no user-channel functionality at all — no `PayloadScope` handling, no
user-channel command routing. Every command it builds is device-channel, so these rows
were pure noise.

This is a MicroMDM → NanoMDM migration regression. MicroMDM keeps user channels in a
separate store behind `/v1/users`, which mdmdirector never calls; its device sync hits
`POST /v1/devices`, which only ever returned real devices.

### Impact

The phantom rows were fed into `pushAll`, which selected all devices unfiltered. Worse,
they can never converge: the sync creates them with zero `Last*` timestamps, and
`deviceNeedsPush` returns `true` unconditionally when any of those is zero — and a user
channel never answers `DeviceInformation`/`SecurityInfo`/`ProfileList`/`CertificateList`,
so they stay zero forever. Result: permanent, self-renewing APNs pushes that wake a user
channel to find an empty queue, plus a distorted `devicesPerMinute` denominator for the
real fleet and an inflated `mdmdirector_devices_total`.

## Changes

- `fetchDevicesFromNanoMDM` now queries with `Types: ["Device", "User Enrollment (Device)"]`
  instead of fetching everything, and additionally skips any enrollment ID whose shape
  identifies a user channel (belt and braces, in case the server-side type filter behaves
  differently than expected). Skipped enrollments are counted and logged.
- `mdm/types.go`: named the five enrollment types (previously only a trailing comment on
  `Enrollment.Type`), added `DeviceChannelEnrollmentTypes`, and added
  `IsUserChannelEnrollmentID`.
- `pushAll` excludes `ud_id LIKE '%:%'` so rows left behind by earlier syncs stay out of
  the push loop.