### PR TITLE
[MDMv2] initialize KMFDDM client whenever KMFDDM is configured, not only when USE_DDM is on

### DIFF
--- a/ddm/client_test.go
+++ b/ddm/client_test.go
@@ -262,3 +262,26 @@ func TestDeleteSetDeclaration_NotFound(t *testing.T) {
 	// Not found is not an error for deletion - association already gone
 	require.NoError(t, err)
 }
+
+// TestClientRequiresInit pins the contract that callers depend on: Client() reports
+// ErrClientNotInitialized until InitClient has run. The per-device DDM opt-in path relies
+// on the client being initialized whenever KMFDDM is configured, not only when the global
+// USE_DDM flags are on — see kmfddmConfigured in main.go.
+func TestClientRequiresInit(t *testing.T) {
+	saved := kmfddmClient
+	t.Cleanup(func() { kmfddmClient = saved })
+
+	kmfddmClient = nil
+	client, err := Client()
+	assert.Nil(t, client)
+	assert.ErrorIs(t, err, ErrClientNotInitialized)
+
+	InitClient("http://kmfddm.example.com:9002/", "test-api-key")
+	client, err = Client()
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	// InitClient trims the trailing slash so joined paths don't double up
+	assert.Equal(t, "http://kmfddm.example.com:9002", client.baseURL)
+	assert.Equal(t, "test-api-key", client.apiKey)
+	assert.Equal(t, KMFDDMAuthUsername, client.username)
+}

--- a/director/profile.go
+++ b/director/profile.go
@@ -306,9 +306,17 @@ func ProcessDeviceProfiles(
 					}
 					_, err = PushProfiles(devices, []types.DeviceProfile{profile}, useDDM)
 					if err != nil {
-						ErrorLogger(LogHolder{Message: err.Error()})
+						ErrorLogger(LogHolder{
+							Message:           err.Error(),
+							DeviceUDID:        device.UDID,
+							DeviceSerial:      device.SerialNumber,
+							ProfileIdentifier: profile.PayloadIdentifier,
+							ProfileUUID:       profile.HashedPayloadUUID,
+						})
+						status = "error"
+					} else {
+						status = "pushed"
 					}
-					status = "pushed"
 				} else {
 					profilesToSave = append(profilesToSave, profile)
 					status = "saved"

--- a/main.go
+++ b/main.go
@@ -151,6 +151,15 @@ var DDMDeclarationPrefix string
 // MDMServerType specifies which MDM server implementation to use (micromdm or nanomdm)
 var MDMServerType string
 
+// kmfddmConfigured reports whether the KMFDDM client can be initialized. DDM needs NanoMDM
+// plus a complete KMFDDM config;
+func kmfddmConfigured(mdmServerType, kmfddmURL, kmfddmAPIKey, declarationPrefix string) bool {
+	return mdmServerType == string(mdm.ServerTypeNanoMDM) &&
+		kmfddmURL != "" &&
+		kmfddmAPIKey != "" &&
+		declarationPrefix != ""
+}
+
 func main() {
 	var port string
 	var debugMode bool
@@ -514,7 +523,17 @@ func main() {
 		if DDMDeclarationPrefix == "" {
 			log.Fatal("DDM declaration prefix is required when DDM is enabled. Exiting.")
 		}
+	}
+
+	// Initialize the KMFDDM client whenever KMFDDM is fully configured,
+	if kmfddmConfigured(MDMServerType, KMFDDMURL, KMFDDMAPIKey, DDMDeclarationPrefix) {
 		ddm.InitClient(KMFDDMURL, KMFDDMAPIKey)
+		director.InfoLogger(director.LogHolder{Message: "KMFDDM client initialized"})
+	} else {
+		log.Warn(
+			"KMFDDM is not fully configured (needs mdm-server-type=nanomdm, kmfddm-url, " +
+				"kmfddm-api-key and ddm-declaration-prefix); per-device DDM opt-in will not work",
+		)
 	}
 
 	if utils.Sign() {


### PR DESCRIPTION
## Problem

Profile removals were failing in prod with HTTP 500 for any device opted into DDM:

{"level":"error","msg":"Delete device profiles: KMFDDM Client not initialized"}

## Root cause

`ddm.InitClient` was only called inside the global flag gate in `main.go`:

```go
if UseDDM || UseDDMPackages {
    // ... validation ...
    ddm.InitClient(KMFDDMURL, KMFDDMAPIKey)
}
```

But the per-device path doesn't consult those globals alone (director/ddm_optin.go):
```
func ddmForDevice(device types.Device) bool {
      return utils.UseDDM() || deviceOptedIntoDDM(device.UDID)
}
```
Prod runs USE_DDM=false / USE_DDM_PACKAGES=false with KMFDDM_URL, KMFDDM_API_KEY and
DDM_DECLARATION_PREFIX all set. So devices in ddm_opt_ins took the DDM code paths against a
nil client. Per the opt-in feature's own doc comment its purpose is to "enable DDM for individual
devices while the global flags remain off" — exactly the configuration in which its client was
never initialized, so the feature could never work.

The two request paths then diverged:

- DELETE /profile → DeleteDeviceProfilesViaDDM → error propagates → HTTP 500.
- POST /profile → PushProfilesViaDDM → error only logged, and status = "pushed" was set
unconditionally → MDMDirector reported success for a profile that was never pushed. 

The loud 500s on removal are the only reason this was noticed; the silent install failures had no
device/profile context in the log line either.

## Changes

- main.go — split the flag gate from client initialization. UseDDM || UseDDMPackages keeps
its existing log.Fatal validation untouched; ddm.InitClient now runs whenever KMFDDM is
fully configured, via a new kmfddmConfigured(mdmServerType, kmfddmURL, kmfddmAPIKey, declarationPrefix). The declaration prefix is part of the precondition because every
declaration identifier is derived from it (ddm.LegacyProfileDeclarationID). Logs
KMFDDM client initialized on success, or an explicit warning that per-device opt-in will not
work when config is incomplete — previously this was silent.
- director/profile.go — status = "pushed" is now set only when PushProfiles succeeds,
"error" otherwise. The error log gains UDID, serial and profile identifier to match the
surrounding call sites.