### PR TITLE
[MDMv2] Log line and metrics for SigningCert expiry

### DIFF
--- a/director/metrics/metrics.go
+++ b/director/metrics/metrics.go
@@ -331,6 +331,27 @@ func DDMEnabledDevices() prometheus.Gauge {
 	return ddmEnabledDevicesTotal
 }
 
+// signingCertNotAfter reports the expiry (NotAfter) of the profile signing certificate as
+// a Unix timestamp, so alerting can warn before it lapses.
+//
+// This exists because expiry is otherwise SILENT: SignProfile signs via pkcs7, which does
+// not validate NotAfter, so an expired certificate keeps signing successfully and no error
+// counter moves. The only downstream evidence is devices rejecting the profiles.
+//
+//nolint:gochecknoglobals
+var signingCertNotAfter = promauto.NewGauge(
+	prometheus.GaugeOpts{
+		Subsystem: subsystem,
+		Name:      "signing_cert_not_after_timestamp_seconds",
+		Help:      "Expiry (NotAfter) of the loaded profile signing certificate, as a Unix timestamp.",
+	},
+)
+
+// SigningCertNotAfter - accessor for signingCertNotAfter
+func SigningCertNotAfter() prometheus.Gauge {
+	return signingCertNotAfter
+}
+
 // ResultLabel maps an HTTP status code or error presence to the canonical result label.
 func ResultLabel(statusCode int) string {
 	if statusCode >= 400 {

--- a/director/profile.go
+++ b/director/profile.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/crypto/pkcs12"
 
@@ -41,7 +42,41 @@ func InitSigningKey() error {
 		utils.KeyPath(),
 		utils.CertPath(),
 	)
-	return err
+	if err != nil {
+		return err
+	}
+
+	reportSigningCertExpiry()
+
+	return nil
+}
+
+const signingCertExpiryInterval = 6 * time.Hour
+
+// PollSigningCertExpiry re-reports the signing certificate's expiry every 6 hours.
+func PollSigningCertExpiry() {
+	go func() {
+		for range time.Tick(signingCertExpiryInterval) {
+			reportSigningCertExpiry()
+		}
+	}()
+}
+
+// reportSigningCertExpiry publishes the loaded signing certificate's expiry as both a
+// gauge and a structured log line. No-op when signing is disabled or the certificate was
+// never loaded - deliberately leaving the gauge UNSET rather than writing 0
+func reportSigningCertExpiry() {
+	if signingCert == nil {
+		return
+	}
+
+	metrics.SigningCertNotAfter().Set(float64(signingCert.NotAfter.Unix()))
+
+	log.WithFields(log.Fields{
+		"cert":              "profile_signing",
+		"not_after":         signingCert.NotAfter.UTC().Format(time.RFC3339),
+		"days_until_expiry": int(time.Until(signingCert.NotAfter).Hours() / 24),
+	}).Info("signing cert expiry check")
 }
 
 func PostProfileHandler(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -639,6 +639,10 @@ func main() {
 		r.Handle("/metrics", promhttp.Handler())
 	}
 
+	if utils.Sign() {
+		director.PollSigningCertExpiry()
+	}
+
 	// Root context cancelled on SIGINT/SIGTERM so background workers and the HTTP
 	// server shut down gracefully.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
Summary

- Adds a signing_cert_not_after_timestamp_seconds gauge that reports the profile signing certificate's expiry (NotAfter) as a Unix timestamp.
- Certificate signing via pkcs7 never validates NotAfter, so an expired cert keeps signing successfully with no error surfaced — the only prior signal was devices rejecting profiles. This gauge lets alerting catch it ahead of time.
- Reports expiry once at signing-key init and then every 6 hours via a new background poller (PollSigningCertExpiry), started from main.go when signing is enabled.
- Also logs a structured line (cert, not_after, days_until_expiry) alongside the metric.
- The gauge is deliberately left unset (not zeroed) when signing is disabled or no cert is loaded, to avoid a misleading "expired" reading.