### PR TITLE
[MDMv2] Don't re-enroll devices with valid ACME cert

### DIFF
--- a/director/certificate.go
+++ b/director/certificate.go
@@ -36,6 +36,7 @@ func processCertificateList(certificateListData types.CertificateListData, devic
 		cert, err := parseCertificate(certListItem)
 		if err != nil {
 			log.Errorf("processCertificateList:parseCertificate: %v", err)
+			continue
 		}
 
 		certificate.Data = certListItem.Data
@@ -46,8 +47,6 @@ func processCertificateList(certificateListData types.CertificateListData, devic
 		certificate.Issuer = cert.Issuer.String()
 		certificates = append(certificates, certificate)
 	}
-
-	// DebugLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: certificates})
 
 	err := db.DB.Model(&device).Association("Certificates").Replace(certificates)
 	if err != nil {
@@ -70,7 +69,68 @@ func parseCertificate(certListItem types.CertificateList) (*x509.Certificate, er
 	return cert, nil
 }
 
-// validateEnrollmentCertExpiry triggers re-enrollment if any SCEP or ACME enrollment cert is nearing expiry
+// enrollmentCerts holds the two certificates that matter to the enrollment decision,
+// picked out of a device's full CertificateList
+type enrollmentCerts struct {
+	// acme is the certificate issued by acme-cert-issuer
+	acme *x509.Certificate
+	// scep is the certificate issued by scep-cert-issuer
+	scep *x509.Certificate
+}
+
+// daysUntil returns whole days from now until t, negative once t has passed.
+func daysUntil(t time.Time) int {
+	return int(time.Until(t).Hours() / 24)
+}
+
+// collectEnrollmentCerts scans a device's whole CertificateList for its ACME identity and
+// its legacy SCEP identity
+func collectEnrollmentCerts(certList []types.CertificateList, device types.Device) enrollmentCerts {
+	scepIssuer := utils.ScepCertIssuer()
+	acmeIssuer := utils.AcmeCertIssuer()
+
+	var found enrollmentCerts
+
+	for _, certListItem := range certList {
+		cert, err := parseCertificate(certListItem)
+		if err != nil {
+			DebugLogger(LogHolder{
+				DeviceSerial: device.SerialNumber,
+				DeviceUDID:   device.UDID,
+				Message:      fmt.Sprintf("Skipping unparseable certificate: %v", err),
+			})
+			continue
+		}
+
+		issuer := cert.Issuer.String()
+		DebugLogger(LogHolder{
+			DeviceSerial: device.SerialNumber,
+			DeviceUDID:   device.UDID,
+			Message:      fmt.Sprintf("Certificate issued by %s issuer", issuer),
+			Metric:       strconv.Itoa(daysUntil(cert.NotAfter)),
+		})
+
+		switch {
+		case acmeIssuer != "" && issuer == acmeIssuer:
+			if found.acme == nil || cert.NotAfter.After(found.acme.NotAfter) {
+				found.acme = cert
+			}
+		case issuer == scepIssuer:
+			if found.scep == nil || cert.NotAfter.After(found.scep.NotAfter) {
+				found.scep = cert
+			}
+		}
+	}
+
+	return found
+}
+
+// validateEnrollmentCertExpiry triggers re-enrollment when the certificate that actually
+// manages the device is nearing expiry
+//
+// The ACME identity takes precedence: once a device holds one it has migrated, and only
+// that certificate's expiry matters. The legacy SCEP certificate is consulted only when
+// the device has no ACME identity
 func validateEnrollmentCertExpiry(certList []types.CertificateList, device types.Device) error {
 	if !utils.EnableReEnrollViaWebhook() {
 		enrollmentProfile := utils.EnrollmentProfile()
@@ -84,43 +144,41 @@ func validateEnrollmentCertExpiry(certList []types.CertificateList, device types
 		}
 	}
 
-	scepIssuer := utils.ScepCertIssuer()
-	scepMinValidity := utils.ScepCertMinValidity()
-	acmeIssuer := utils.AcmeCertIssuer()
-	acmeMinValidity := utils.AcmeCertMinValidity()
+	found := collectEnrollmentCerts(certList, device)
 
-	var nearingExpiry bool
+	var (
+		cert        *x509.Certificate
+		minValidity int
+		kind        string
+	)
 
-	for _, certListItem := range certList {
-		cert, err := parseCertificate(certListItem)
-		if err != nil {
-			return errors.Wrap(err, "failed to parse certificate")
-		}
-
-		issuer := cert.Issuer.String()
-		days := int(time.Until(cert.NotAfter).Hours() / 24)
-
-		msg := fmt.Sprintf("Certificate issued by %s issuer", issuer)
-		DebugLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: msg, Metric: strconv.Itoa(days)})
-
-		if issuer == scepIssuer {
-			if days <= scepMinValidity {
-				InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: msg, Metric: strconv.Itoa(days)})
-				nearingExpiry = true
-				break
-			}
-		} else if acmeIssuer != "" && issuer == acmeIssuer {
-			if days <= acmeMinValidity {
-				InfoLogger(LogHolder{DeviceSerial: device.SerialNumber, DeviceUDID: device.UDID, Message: msg, Metric: strconv.Itoa(days)})
-				nearingExpiry = true
-				break
-			}
-		}
+	switch {
+	case found.acme != nil:
+		cert, minValidity, kind = found.acme, utils.AcmeCertMinValidity(), "ACME"
+	case found.scep != nil:
+		cert, minValidity, kind = found.scep, utils.ScepCertMinValidity(), "SCEP"
+	default:
+		// Neither enrollment certificate is on the device; nothing to renew.
+		return nil
 	}
 
-	if nearingExpiry {
-		return reinstallEnrollmentProfile(device)
+	days := daysUntil(cert.NotAfter)
+	if days > minValidity {
+		DebugLogger(LogHolder{
+			DeviceSerial: device.SerialNumber,
+			DeviceUDID:   device.UDID,
+			Message:      fmt.Sprintf("%s enrollment certificate is valid, not re-enrolling", kind),
+			Metric:       strconv.Itoa(days),
+		})
+		return nil
 	}
 
-	return nil
+	InfoLogger(LogHolder{
+		DeviceSerial: device.SerialNumber,
+		DeviceUDID:   device.UDID,
+		Message:      fmt.Sprintf("Certificate issued by %s issuer", cert.Issuer.String()),
+		Metric:       strconv.Itoa(days),
+	})
+
+	return reinstallEnrollmentProfile(device)
 }

--- a/director/certificate_test.go
+++ b/director/certificate_test.go
@@ -114,7 +114,7 @@ func certTestDevice() types.Device {
 func configureCertFlags(
 	t *testing.T,
 	certList []types.CertificateList,
-	scepMinValidity, acmeMinValidity string,
+	acmeMinValidity string,
 ) *int {
 	t.Helper()
 	registerCertFlags(t)
@@ -131,7 +131,7 @@ func configureCertFlags(
 	setFlag(t, "enable-reenroll-via-webhook", "true")
 	setFlag(t, "enroll-webhook-url", server.URL)
 	setFlag(t, "enroll-webhook-token", "test-token")
-	setFlag(t, "scep-cert-min-validity", scepMinValidity)
+	setFlag(t, "scep-cert-min-validity", "10000")
 	setFlag(t, "acme-cert-min-validity", acmeMinValidity)
 	setFlag(t, "scep-cert-issuer", issuerString(t, findByIssuerCN(t, certList, certTestScepIssuerCN)))
 	setFlag(t, "acme-cert-issuer", issuerString(t, findByIssuerCN(t, certList, certTestAcmeIssuerCN)))
@@ -160,12 +160,12 @@ func findByIssuerCN(t *testing.T, certList []types.CertificateList, cn string) [
 // The unrelated entries are filler standing in for the assorted CA and vendor
 // certificates a real device accumulates, including one long expired - none of them should
 // influence the decision.
-func scepBeforeAcmeCertList(t *testing.T, scepDays, acmeDays int) []types.CertificateList {
+func scepBeforeAcmeCertList(t *testing.T, acmeDays int) []types.CertificateList {
 	t.Helper()
 	return []types.CertificateList{
 		makeCert(t, "System Default CA", 7248),
 		makeCert(t, "System Kerberos CA", 7248),
-		makeCert(t, certTestScepIssuerCN, scepDays),
+		makeCert(t, certTestScepIssuerCN, 1043),
 		makeCert(t, "Unrelated Vendor Root CA", 819),
 		makeCert(t, "Unrelated Corporate Root CA", 33118),
 		makeCert(t, "Unrelated Agent CA", 1082),
@@ -178,8 +178,8 @@ func scepBeforeAcmeCertList(t *testing.T, scepDays, acmeDays int) []types.Certif
 // collectEnrollmentCerts is the part that decides; assert on it directly so the tests do
 // not depend on reinstallEnrollmentProfile's transport.
 func TestCollectEnrollmentCerts_FindsAcmeAfterScepInList(t *testing.T) {
-	certList := scepBeforeAcmeCertList(t, 1043, 3646)
-	configureCertFlags(t, certList, "10000", "180")
+	certList := scepBeforeAcmeCertList(t, 3646)
+	configureCertFlags(t, certList, "180")
 
 	found := collectEnrollmentCerts(certList, certTestDevice())
 
@@ -193,8 +193,8 @@ func TestCollectEnrollmentCerts_FindsAcmeAfterScepInList(t *testing.T) {
 // certificate must not be re-enrolled, however high scep-cert-min-validity is set. Before
 // the fix this fetched a fresh enrollment profile on every check-in, forever.
 func TestValidateEnrollmentCertExpiry_HealthyAcmeWinsOverStaleScep(t *testing.T) {
-	certList := scepBeforeAcmeCertList(t, 1043, 3646)
-	fetches := configureCertFlags(t, certList, "10000", "180")
+	certList := scepBeforeAcmeCertList(t, 3646)
+	fetches := configureCertFlags(t, certList, "180")
 
 	err := validateEnrollmentCertExpiry(certList, certTestDevice())
 
@@ -205,8 +205,8 @@ func TestValidateEnrollmentCertExpiry_HealthyAcmeWinsOverStaleScep(t *testing.T)
 // A device with no ACME identity must still be re-enrolled, so a high
 // scep-cert-min-validity keeps working as a way to move devices off SCEP.
 func TestValidateEnrollmentCertExpiry_ScepOnlyStillTriggers(t *testing.T) {
-	certList := scepBeforeAcmeCertList(t, 1043, 3646)
-	fetches := configureCertFlags(t, certList, "10000", "180")
+	certList := scepBeforeAcmeCertList(t, 3646)
+	fetches := configureCertFlags(t, certList, "180")
 
 	// Drop the ACME identity, leaving the ordering otherwise intact.
 	scepOnly := certList[:len(certList)-1]
@@ -219,8 +219,8 @@ func TestValidateEnrollmentCertExpiry_ScepOnlyStillTriggers(t *testing.T) {
 
 // An expiring ACME identity is a genuine renewal and must trigger.
 func TestValidateEnrollmentCertExpiry_ExpiringAcmeTriggers(t *testing.T) {
-	certList := scepBeforeAcmeCertList(t, 1043, 30)
-	fetches := configureCertFlags(t, certList, "10000", "180")
+	certList := scepBeforeAcmeCertList(t, 30)
+	fetches := configureCertFlags(t, certList, "180")
 
 	err := validateEnrollmentCertExpiry(certList, certTestDevice())
 
@@ -230,8 +230,8 @@ func TestValidateEnrollmentCertExpiry_ExpiringAcmeTriggers(t *testing.T) {
 
 // One malformed entry must not abandon the whole check.
 func TestCollectEnrollmentCerts_SkipsUnparseableCert(t *testing.T) {
-	certList := scepBeforeAcmeCertList(t, 1043, 3646)
-	configureCertFlags(t, certList, "10000", "180")
+	certList := scepBeforeAcmeCertList(t, 3646)
+	configureCertFlags(t, certList, "180")
 
 	withGarbage := append([]types.CertificateList{{Data: []byte("not-a-certificate")}}, certList...)
 
@@ -243,8 +243,8 @@ func TestCollectEnrollmentCerts_SkipsUnparseableCert(t *testing.T) {
 
 // Longest-lived wins, so a stale duplicate cannot force a needless re-enrollment.
 func TestCollectEnrollmentCerts_PrefersLongestLived(t *testing.T) {
-	certList := scepBeforeAcmeCertList(t, 1043, 3646)
-	configureCertFlags(t, certList, "10000", "180")
+	certList := scepBeforeAcmeCertList(t, 3646)
+	configureCertFlags(t, certList, "180")
 
 	withStaleDupe := append([]types.CertificateList{makeCert(t, certTestAcmeIssuerCN, 10)}, certList...)
 

--- a/director/certificate_test.go
+++ b/director/certificate_test.go
@@ -1,0 +1,255 @@
+package director
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"flag"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/micromdm/go4/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	certTestScepIssuerCN = "Test SCEP CA"
+	certTestAcmeIssuerCN = "Test ACME Intermediate CA"
+	certTestSerial       = "TESTSERIAL01"
+	certTestUDID         = "00000000-0000-0000-0000-000000000001"
+)
+
+// registerCertFlags registers the flags validateEnrollmentCertExpiry and the webhook
+// re-enrollment path read.
+//
+// It deliberately registers only what these tests need instead of reusing
+// registerEnrollmentProfileFlags: that helper also registers "micromdmurl", which
+// command_test.go registers unguarded, and this file sorts first in the package - so
+// claiming that flag here would panic the later test.
+func registerCertFlags(t *testing.T) {
+	t.Helper()
+	if flag.Lookup("enable-reenroll-via-webhook") == nil {
+		flag.Bool("enable-reenroll-via-webhook", env.Bool("ENABLE_REENROLL_VIA_WEBHOOK", false), "Enable webhook-based re-enrollment.")
+	}
+	if flag.Lookup("enroll-webhook-url") == nil {
+		flag.String("enroll-webhook-url", env.String("ENROLL_WEBHOOK_URL", ""), "Enrollment profile webhook URL.")
+	}
+	if flag.Lookup("enroll-webhook-token") == nil {
+		flag.String("enroll-webhook-token", env.String("ENROLL_WEBHOOK_TOKEN", ""), "Enrollment profile webhook bearer token.")
+	}
+	if flag.Lookup("scep-cert-issuer") == nil {
+		flag.String("scep-cert-issuer", env.String("SCEP_CERT_ISSUER", ""), "SCEP cert issuer.")
+	}
+	if flag.Lookup("scep-cert-min-validity") == nil {
+		flag.Int("scep-cert-min-validity", env.Int("SCEP_CERT_MIN_VALIDITY", 180), "SCEP min validity in days.")
+	}
+	if flag.Lookup("acme-cert-issuer") == nil {
+		flag.String("acme-cert-issuer", env.String("ACME_CERT_ISSUER", ""), "ACME cert issuer.")
+	}
+	if flag.Lookup("acme-cert-min-validity") == nil {
+		flag.Int("acme-cert-min-validity", env.Int("ACME_CERT_MIN_VALIDITY", 180), "ACME min validity in days.")
+	}
+}
+
+// issuerString renders a certificate's issuer exactly as x509 does, so the issuer the
+// tests configure matches what the code compares against.
+func issuerString(t *testing.T, der []byte) string {
+	t.Helper()
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert.Issuer.String()
+}
+
+// makeCert mints a certificate whose Issuer CN is issuerCN, expiring in validForDays.
+func makeCert(t *testing.T, issuerCN string, validForDays int) types.CertificateList {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// The extra hour keeps daysUntil's truncating division landing on exactly
+	// validForDays rather than one less once a few milliseconds have elapsed.
+	notAfter := time.Now().Add(time.Duration(validForDays)*24*time.Hour + time.Hour)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "leaf"},
+		Issuer:       pkix.Name{CommonName: issuerCN},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+	}
+
+	// Self-signing would force Issuer == tmpl.Subject, so sign against a parent that
+	// carries the issuer name we want.
+	parent := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: issuerCN},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter.Add(24 * time.Hour),
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return types.CertificateList{Data: der}
+}
+
+func certTestDevice() types.Device {
+	return types.Device{UDID: certTestUDID, SerialNumber: certTestSerial}
+}
+
+// configureCertFlags points the flags at the issuers the fixtures actually used and wires
+// re-enrollment at a webhook stub, returning a counter of how many times the enrollment
+// profile was fetched. Whether that counter moves is the real observable: one fetch is one
+// re-enrollment.
+//
+// The stub answers 500 so reinstallEnrollmentProfile stops there rather than going on to
+// sign and push a profile.
+func configureCertFlags(
+	t *testing.T,
+	certList []types.CertificateList,
+	scepMinValidity, acmeMinValidity string,
+) *int {
+	t.Helper()
+	registerCertFlags(t)
+
+	fetches := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetches++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	// Webhook mode clears the enrollment-profile-on-disk preflight, which would otherwise
+	// return before the expiry decision is ever made.
+	setFlag(t, "enable-reenroll-via-webhook", "true")
+	setFlag(t, "enroll-webhook-url", server.URL)
+	setFlag(t, "enroll-webhook-token", "test-token")
+	setFlag(t, "scep-cert-min-validity", scepMinValidity)
+	setFlag(t, "acme-cert-min-validity", acmeMinValidity)
+	setFlag(t, "scep-cert-issuer", issuerString(t, findByIssuerCN(t, certList, certTestScepIssuerCN)))
+	setFlag(t, "acme-cert-issuer", issuerString(t, findByIssuerCN(t, certList, certTestAcmeIssuerCN)))
+
+	return &fetches
+}
+
+func findByIssuerCN(t *testing.T, certList []types.CertificateList, cn string) []byte {
+	t.Helper()
+	for _, item := range certList {
+		cert, err := x509.ParseCertificate(item.Data)
+		require.NoError(t, err)
+		if cert.Issuer.CommonName == cn {
+			return item.Data
+		}
+	}
+	t.Fatalf("no fixture certificate issued by %q", cn)
+	return nil
+}
+
+// scepBeforeAcmeCertList models the case this logic exists for: a device that already
+// holds an ACME identity but still has its old SCEP certificate, with the SCEP one
+// appearing FIRST and the ACME one last behind several unrelated certificates. A scan that
+// stops at the first matching issuer never reaches the ACME identity.
+//
+// The unrelated entries are filler standing in for the assorted CA and vendor
+// certificates a real device accumulates, including one long expired - none of them should
+// influence the decision.
+func scepBeforeAcmeCertList(t *testing.T, scepDays, acmeDays int) []types.CertificateList {
+	t.Helper()
+	return []types.CertificateList{
+		makeCert(t, "System Default CA", 7248),
+		makeCert(t, "System Kerberos CA", 7248),
+		makeCert(t, certTestScepIssuerCN, scepDays),
+		makeCert(t, "Unrelated Vendor Root CA", 819),
+		makeCert(t, "Unrelated Corporate Root CA", 33118),
+		makeCert(t, "Unrelated Agent CA", 1082),
+		makeCert(t, "Unrelated Expired CA", -928),
+		makeCert(t, "Unrelated Vendor CA", 5893),
+		makeCert(t, certTestAcmeIssuerCN, acmeDays),
+	}
+}
+
+// collectEnrollmentCerts is the part that decides; assert on it directly so the tests do
+// not depend on reinstallEnrollmentProfile's transport.
+func TestCollectEnrollmentCerts_FindsAcmeAfterScepInList(t *testing.T) {
+	certList := scepBeforeAcmeCertList(t, 1043, 3646)
+	configureCertFlags(t, certList, "10000", "180")
+
+	found := collectEnrollmentCerts(certList, certTestDevice())
+
+	require.NotNil(t, found.scep, "SCEP certificate should be found where it appears first")
+	require.NotNil(t, found.acme, "ACME identity must still be found past the SCEP match")
+	assert.Equal(t, 3646, daysUntil(found.acme.NotAfter))
+	assert.Equal(t, 1043, daysUntil(found.scep.NotAfter))
+}
+
+// The regression this fixes: a device with a healthy ACME identity and a stale SCEP
+// certificate must not be re-enrolled, however high scep-cert-min-validity is set. Before
+// the fix this fetched a fresh enrollment profile on every check-in, forever.
+func TestValidateEnrollmentCertExpiry_HealthyAcmeWinsOverStaleScep(t *testing.T) {
+	certList := scepBeforeAcmeCertList(t, 1043, 3646)
+	fetches := configureCertFlags(t, certList, "10000", "180")
+
+	err := validateEnrollmentCertExpiry(certList, certTestDevice())
+
+	assert.NoError(t, err, "a healthy ACME identity must suppress the SCEP check entirely")
+	assert.Zero(t, *fetches, "no enrollment profile should be fetched")
+}
+
+// A device with no ACME identity must still be re-enrolled, so a high
+// scep-cert-min-validity keeps working as a way to move devices off SCEP.
+func TestValidateEnrollmentCertExpiry_ScepOnlyStillTriggers(t *testing.T) {
+	certList := scepBeforeAcmeCertList(t, 1043, 3646)
+	fetches := configureCertFlags(t, certList, "10000", "180")
+
+	// Drop the ACME identity, leaving the ordering otherwise intact.
+	scepOnly := certList[:len(certList)-1]
+
+	err := validateEnrollmentCertExpiry(scepOnly, certTestDevice())
+
+	require.Error(t, err, "the webhook stub answers 500, so a fired trigger surfaces here")
+	assert.Equal(t, 1, *fetches, "a SCEP-only device must still be re-enrolled")
+}
+
+// An expiring ACME identity is a genuine renewal and must trigger.
+func TestValidateEnrollmentCertExpiry_ExpiringAcmeTriggers(t *testing.T) {
+	certList := scepBeforeAcmeCertList(t, 1043, 30)
+	fetches := configureCertFlags(t, certList, "10000", "180")
+
+	err := validateEnrollmentCertExpiry(certList, certTestDevice())
+
+	require.Error(t, err)
+	assert.Equal(t, 1, *fetches, "an ACME identity inside min-validity must be renewed")
+}
+
+// One malformed entry must not abandon the whole check.
+func TestCollectEnrollmentCerts_SkipsUnparseableCert(t *testing.T) {
+	certList := scepBeforeAcmeCertList(t, 1043, 3646)
+	configureCertFlags(t, certList, "10000", "180")
+
+	withGarbage := append([]types.CertificateList{{Data: []byte("not-a-certificate")}}, certList...)
+
+	found := collectEnrollmentCerts(withGarbage, certTestDevice())
+
+	require.NotNil(t, found.acme, "parsing must continue past a malformed certificate")
+	require.NotNil(t, found.scep)
+}
+
+// Longest-lived wins, so a stale duplicate cannot force a needless re-enrollment.
+func TestCollectEnrollmentCerts_PrefersLongestLived(t *testing.T) {
+	certList := scepBeforeAcmeCertList(t, 1043, 3646)
+	configureCertFlags(t, certList, "10000", "180")
+
+	withStaleDupe := append([]types.CertificateList{makeCert(t, certTestAcmeIssuerCN, 10)}, certList...)
+
+	found := collectEnrollmentCerts(withStaleDupe, certTestDevice())
+
+	require.NotNil(t, found.acme)
+	assert.Equal(t, 3646, daysUntil(found.acme.NotAfter), "the longer-lived identity should win")
+}

--- a/director/certificate_test.go
+++ b/director/certificate_test.go
@@ -114,7 +114,6 @@ func certTestDevice() types.Device {
 func configureCertFlags(
 	t *testing.T,
 	certList []types.CertificateList,
-	acmeMinValidity string,
 ) *int {
 	t.Helper()
 	registerCertFlags(t)
@@ -132,7 +131,7 @@ func configureCertFlags(
 	setFlag(t, "enroll-webhook-url", server.URL)
 	setFlag(t, "enroll-webhook-token", "test-token")
 	setFlag(t, "scep-cert-min-validity", "10000")
-	setFlag(t, "acme-cert-min-validity", acmeMinValidity)
+	setFlag(t, "acme-cert-min-validity", "180")
 	setFlag(t, "scep-cert-issuer", issuerString(t, findByIssuerCN(t, certList, certTestScepIssuerCN)))
 	setFlag(t, "acme-cert-issuer", issuerString(t, findByIssuerCN(t, certList, certTestAcmeIssuerCN)))
 
@@ -179,7 +178,7 @@ func scepBeforeAcmeCertList(t *testing.T, acmeDays int) []types.CertificateList 
 // not depend on reinstallEnrollmentProfile's transport.
 func TestCollectEnrollmentCerts_FindsAcmeAfterScepInList(t *testing.T) {
 	certList := scepBeforeAcmeCertList(t, 3646)
-	configureCertFlags(t, certList, "180")
+	configureCertFlags(t, certList)
 
 	found := collectEnrollmentCerts(certList, certTestDevice())
 
@@ -194,7 +193,7 @@ func TestCollectEnrollmentCerts_FindsAcmeAfterScepInList(t *testing.T) {
 // the fix this fetched a fresh enrollment profile on every check-in, forever.
 func TestValidateEnrollmentCertExpiry_HealthyAcmeWinsOverStaleScep(t *testing.T) {
 	certList := scepBeforeAcmeCertList(t, 3646)
-	fetches := configureCertFlags(t, certList, "180")
+	fetches := configureCertFlags(t, certList)
 
 	err := validateEnrollmentCertExpiry(certList, certTestDevice())
 
@@ -206,7 +205,7 @@ func TestValidateEnrollmentCertExpiry_HealthyAcmeWinsOverStaleScep(t *testing.T)
 // scep-cert-min-validity keeps working as a way to move devices off SCEP.
 func TestValidateEnrollmentCertExpiry_ScepOnlyStillTriggers(t *testing.T) {
 	certList := scepBeforeAcmeCertList(t, 3646)
-	fetches := configureCertFlags(t, certList, "180")
+	fetches := configureCertFlags(t, certList)
 
 	// Drop the ACME identity, leaving the ordering otherwise intact.
 	scepOnly := certList[:len(certList)-1]
@@ -220,7 +219,7 @@ func TestValidateEnrollmentCertExpiry_ScepOnlyStillTriggers(t *testing.T) {
 // An expiring ACME identity is a genuine renewal and must trigger.
 func TestValidateEnrollmentCertExpiry_ExpiringAcmeTriggers(t *testing.T) {
 	certList := scepBeforeAcmeCertList(t, 30)
-	fetches := configureCertFlags(t, certList, "180")
+	fetches := configureCertFlags(t, certList)
 
 	err := validateEnrollmentCertExpiry(certList, certTestDevice())
 
@@ -231,7 +230,7 @@ func TestValidateEnrollmentCertExpiry_ExpiringAcmeTriggers(t *testing.T) {
 // One malformed entry must not abandon the whole check.
 func TestCollectEnrollmentCerts_SkipsUnparseableCert(t *testing.T) {
 	certList := scepBeforeAcmeCertList(t, 3646)
-	configureCertFlags(t, certList, "180")
+	configureCertFlags(t, certList)
 
 	withGarbage := append([]types.CertificateList{{Data: []byte("not-a-certificate")}}, certList...)
 
@@ -244,7 +243,7 @@ func TestCollectEnrollmentCerts_SkipsUnparseableCert(t *testing.T) {
 // Longest-lived wins, so a stale duplicate cannot force a needless re-enrollment.
 func TestCollectEnrollmentCerts_PrefersLongestLived(t *testing.T) {
 	certList := scepBeforeAcmeCertList(t, 3646)
-	configureCertFlags(t, certList, "180")
+	configureCertFlags(t, certList)
 
 	withStaleDupe := append([]types.CertificateList{makeCert(t, certTestAcmeIssuerCN, 10)}, certList...)
 


### PR DESCRIPTION
## Problem

A device that has been moved from SCEP to ACME keeps its old SCEP certificate in the
keychain — the new enrollment profile does not remove it. `validateEnrollmentCertExpiry`
scanned `CertificateList` in order, triggered on the **first** issuer it matched, and
`break`ed. When the stale SCEP certificate appears before the ACME identity, the device is
judged on the SCEP certificate and re-enrolled, even though it holds a healthy ACME
identity with years of validity left.

Nothing clears the condition, so it repeats on every check-in. The reinstall itself makes
it worse: pushing an enrollment profile causes the device to re-enroll, which re-runs
initial tasks, which requests `CertificateList` again — closing the loop.

## Fix

`validateEnrollmentCertExpiry` now decides on top of a full scan rather than exiting early:

- **Read the whole list.** `collectEnrollmentCerts` no longer stops at the first match.
  Both certificates can be present at once and in any order, so no decision is sound until
  the entire list has been read.
- **ACME takes precedence.** If the device has a certificate from `acme-cert-issuer`, only
  its expiry matters. `scep-cert-issuer` is consulted only when there is no ACME
  certificate — which keeps a high `scep-cert-min-validity` working as a way to move
  devices off SCEP.
- **Longest-lived wins per issuer,** so a stale duplicate cannot force a needless
  re-enrollment.
- **A malformed certificate is skipped** instead of aborting the check for the whole
  device.

### Behaviour

| Device state | Before | After |
|---|---|---|
| ACME valid, stale SCEP present | Re-enrolled every check-in | No action |
| ACME valid, no SCEP | No action | No action |
| ACME within `acme-cert-min-validity` | Renewed | Renewed |
| SCEP only, within `scep-cert-min-validity` | Re-enrolled | Re-enrolled |
| Neither certificate present | No action | No action |
| One certificate unparseable | Whole check aborted | Entry skipped, check continues |
