### PR TITLE
fix(db): recycle idle connections before the mesh resets them

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -75,7 +75,13 @@ func Open() error {
 	sqlDB.SetMaxOpenConns(utils.DBMaxConnections())
 
 	// SetConnMaxLifetime sets the maximum amount of time a connection may be reused.
-	sqlDB.SetConnMaxLifetime(time.Hour)
+	sqlDB.SetConnMaxLifetime(time.Duration(utils.DBConnMaxLifetime()) * time.Second)
+
+	// SetConnMaxIdleTime closes idle connections before an in-mesh proxy (Istio
+	// sidecar / NLB) resets them out from under the pool. Without this, the pool
+	// hands a silently-dead connection to the next query, which fails with
+	// "connection reset by peer" / "unexpected EOF".
+	sqlDB.SetConnMaxIdleTime(time.Duration(utils.DBConnMaxIdleTime()) * time.Second)
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -67,6 +67,12 @@ var DBMaxIdleConnections int
 
 var DBMaxConnections int
 
+// DBConnMaxIdleTimeSeconds bounds how long a connection may sit idle in the pool.
+var DBConnMaxIdleTimeSeconds int
+
+// DBConnMaxLifetimeSeconds bounds how long a connection may be reused.
+var DBConnMaxLifetimeSeconds int
+
 // DBSSLMode is used to connect to the database
 var DBSSLMode string
 
@@ -279,6 +285,18 @@ func main() {
 		"db-max-connections",
 		100,
 		"Maximum number of database connections",
+	)
+	flag.IntVar(
+		&DBConnMaxIdleTimeSeconds,
+		"db-conn-max-idle-time",
+		env.Int("DB_CONN_MAX_IDLE_TIME", 240),
+		"Maximum seconds a connection may sit idle in the pool before being closed. Keep below the Istio/NLB idle timeout so the pool recycles connections before the mesh resets them. 0 disables the limit.",
+	)
+	flag.IntVar(
+		&DBConnMaxLifetimeSeconds,
+		"db-conn-max-lifetime",
+		env.Int("DB_CONN_MAX_LIFETIME", 1800),
+		"Maximum seconds a connection may be reused before being closed. 0 means connections are reused forever.",
 	)
 	flag.StringVar(
 		&LogLevel,

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -86,6 +86,14 @@ func DBMaxConnections() int {
 	return flag.Lookup("db-max-connections").Value.(flag.Getter).Get().(int)
 }
 
+func DBConnMaxIdleTime() int {
+	return flag.Lookup("db-conn-max-idle-time").Value.(flag.Getter).Get().(int)
+}
+
+func DBConnMaxLifetime() int {
+	return flag.Lookup("db-conn-max-lifetime").Value.(flag.Getter).Get().(int)
+}
+
 func EscrowURL() string {
 	return flag.Lookup("escrowurl").Value.(flag.Getter).Get().(string)
 }


### PR DESCRIPTION
## Summary

mdmdirector's Postgres traffic is routed through a mesh that resets long-lived idle connections. The `database/sql` pool then hands a silently-dead connection to the next query, which fails with `connection reset by peer` or `unexpected EOF`. In dev this fires hundreds of times a day, clustered during idle periods. It surfaces to callers such as Puppet as an intermittent connection issue, more often on per-device (non-shared) profile pushes because they do more synchronous DB round-trips per request than a shared push.

This adds `SetConnMaxIdleTime` so the pool proactively closes idle connections before the mesh or NLB tears them down, and makes `ConnMaxLifetime` configurable instead of a hardcoded 1 hour. Both are tunable via env vars so operators can keep the idle timeout under the NLB idle window without a rebuild:
- `DB_CONN_MAX_IDLE_TIME` (flag `db-conn-max-idle-time`), default 240s
- `DB_CONN_MAX_LIFETIME` (flag `db-conn-max-lifetime`), default 1800s


## Test Plan

- `go build ./...` and `go vet ./...` pass.
- Existing default (`db-max-idle-connections` unchanged) is preserved; only adds the two time-based knobs.
- Verify in dev after deploy: `connection reset by peer` / `unexpected EOF` in mdmdirector logs drop to zero, and a non-shared profile push from Puppet completes without a connection error.