### PR TITLE
[MDMv2] DB metrics for pool health and operation outcomes

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 
+	"github.com/mdmdirector/mdmdirector/director/metrics"
 	"github.com/mdmdirector/mdmdirector/utils"
 	"github.com/pkg/errors"
 
@@ -76,6 +77,16 @@ func Open() error {
 
 	// SetConnMaxLifetime sets the maximum amount of time a connection may be reused.
 	sqlDB.SetConnMaxLifetime(time.Hour)
+
+	if utils.Prometheus() {
+		if err := metrics.RegisterDBStats(sqlDB, utils.DBName()); err != nil {
+			return errors.Wrap(err, "registering db pool metrics")
+		}
+
+		if err := registerMetricsCallbacks(DB); err != nil {
+			return errors.Wrap(err, "registering db metrics callbacks")
+		}
+	}
 
 	return nil
 }

--- a/db/metrics.go
+++ b/db/metrics.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"syscall"
+
+	"github.com/jackc/pgconn"
+	"gorm.io/gorm"
+
+	"github.com/mdmdirector/mdmdirector/director/metrics"
+)
+
+// registerMetricsCallbacks counts the outcome of every gorm operation.
+//
+// Most database errors in mdmdirector are logged as a bare message and nothing
+// else, which makes them impossible to alert on and impossible to tell apart
+// from unrelated failures with the same wording. Counting them here, classified
+// by cause, gives one place to watch regardless of which call site failed.
+//
+// The callbacks are ordered "*" so they run last, after the transaction gorm
+// wraps writes in has been committed or rolled back, and therefore see the
+// error the caller will see.
+func registerMetricsCallbacks(gdb *gorm.DB) error {
+	c := gdb.Callback()
+
+	if err := c.Create().After("*").Register("metrics:after_create", metricsAfter("create")); err != nil {
+		return err
+	}
+	if err := c.Query().After("*").Register("metrics:after_query", metricsAfter("query")); err != nil {
+		return err
+	}
+	if err := c.Update().After("*").Register("metrics:after_update", metricsAfter("update")); err != nil {
+		return err
+	}
+	if err := c.Delete().After("*").Register("metrics:after_delete", metricsAfter("delete")); err != nil {
+		return err
+	}
+	if err := c.Row().After("*").Register("metrics:after_row", metricsAfter("row")); err != nil {
+		return err
+	}
+	if err := c.Raw().After("*").Register("metrics:after_raw", metricsAfter("raw")); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func metricsAfter(operation string) func(*gorm.DB) {
+	return func(tx *gorm.DB) {
+		metrics.DBOperations(operation, dbResult(tx.Error)).Inc()
+	}
+}
+
+// dbResult classifies a database error so the counter can separate a broken
+// connection from a rejected statement. The checks are on error identity rather
+// than on message text.
+func dbResult(err error) string {
+	switch {
+	case err == nil:
+		return metrics.DBResultSuccess
+
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return metrics.DBResultNotFound
+
+	case isPostgresError(err):
+		return metrics.DBResultPostgresError
+
+	case errors.Is(err, context.Canceled):
+		return metrics.DBResultCanceled
+
+	case errors.Is(err, context.DeadlineExceeded),
+		errors.Is(err, os.ErrDeadlineExceeded),
+		pgconn.Timeout(err):
+		return metrics.DBResultTimeout
+
+	case errors.Is(err, driver.ErrBadConn),
+		errors.Is(err, io.ErrUnexpectedEOF),
+		errors.Is(err, io.EOF),
+		errors.Is(err, syscall.ECONNRESET),
+		errors.Is(err, syscall.EPIPE),
+		errors.Is(err, net.ErrClosed):
+		return metrics.DBResultStaleConnection
+
+	default:
+		return metrics.DBResultOther
+	}
+}
+
+// isPostgresError reports whether Postgres itself rejected the statement, which
+// says nothing about the health of the connection.
+func isPostgresError(err error) bool {
+	var pgErr *pgconn.PgError
+
+	return errors.As(err, &pgErr)
+}

--- a/db/metrics_test.go
+++ b/db/metrics_test.go
@@ -1,0 +1,144 @@
+package db
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jackc/pgconn"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+
+	"github.com/mdmdirector/mdmdirector/director/metrics"
+)
+
+func TestDBResult(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"no error", nil, metrics.DBResultSuccess},
+		{"no rows", gorm.ErrRecordNotFound, metrics.DBResultNotFound},
+		{
+			"postgres rejected the statement",
+			&pgconn.PgError{Code: "23505", Message: "duplicate key value"},
+			metrics.DBResultPostgresError,
+		},
+		{"caller gave up", context.Canceled, metrics.DBResultCanceled},
+		{"ran out of time", context.DeadlineExceeded, metrics.DBResultTimeout},
+		{"socket deadline", os.ErrDeadlineExceeded, metrics.DBResultTimeout},
+		// The exact error pgproto3 produces when the far end closes the socket,
+		// which is the failure this instrumentation exists to make visible.
+		{"closed socket", io.ErrUnexpectedEOF, metrics.DBResultStaleConnection},
+		{"pool rejected the connection", driver.ErrBadConn, metrics.DBResultStaleConnection},
+		{"connection reset", &net.OpError{Err: syscall.ECONNRESET}, metrics.DBResultStaleConnection},
+		{"broken pipe", &net.OpError{Err: syscall.EPIPE}, metrics.DBResultStaleConnection},
+		{"unknown failure", errors.New("something else"), metrics.DBResultOther},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dbResult(tt.err); got != tt.want {
+				t.Errorf("dbResult(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// Errors reach the classifier wrapped by gorm and by pgconn, so identity checks
+// have to survive the layers rather than only matching a bare sentinel.
+func TestDBResultSeesThroughWrapping(t *testing.T) {
+	wrapped := fmt.Errorf("running query: %w", fmt.Errorf("receive message failed: %w", io.ErrUnexpectedEOF))
+
+	if got := dbResult(wrapped); got != metrics.DBResultStaleConnection {
+		t.Errorf("dbResult(wrapped EOF) = %q, want %q", got, metrics.DBResultStaleConnection)
+	}
+}
+
+// A dead connection has to show up on the counter, through real gorm callbacks,
+// or the alert built on it will stay silent during the next incident.
+//
+// Note the operation label: Raw().Scan() runs through gorm's Row processor, not
+// its Raw one, which is only visible by watching what the callbacks report.
+func TestMetricsCallbacksCountStaleConnection(t *testing.T) {
+	mockDB, spy, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("creating mock: %v", err)
+	}
+	defer mockDB.Close()
+
+	gdb, err := gorm.Open(
+		postgres.New(postgres.Config{Conn: mockDB}),
+		&gorm.Config{SkipDefaultTransaction: true},
+	)
+	if err != nil {
+		t.Fatalf("opening gorm: %v", err)
+	}
+
+	if err := registerMetricsCallbacks(gdb); err != nil {
+		t.Fatalf("registering callbacks: %v", err)
+	}
+
+	before := testutil.ToFloat64(metrics.DBOperations("row", metrics.DBResultStaleConnection))
+
+	spy.ExpectQuery(`.*`).WillReturnError(io.ErrUnexpectedEOF)
+
+	var count int64
+	_ = gdb.Raw("SELECT count(*) FROM devices").Scan(&count).Error
+
+	after := testutil.ToFloat64(metrics.DBOperations("row", metrics.DBResultStaleConnection))
+
+	if after != before+1 {
+		t.Errorf("stale_connection count went from %v to %v, wanted one increment", before, after)
+	}
+}
+
+type metricsTestRow struct {
+	ID int64
+}
+
+// A healthy query must not land in an error bucket, or the alert is noise. This
+// one goes through the Query processor, which is what most call sites use.
+func TestMetricsCallbacksCountSuccess(t *testing.T) {
+	mockDB, spy, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("creating mock: %v", err)
+	}
+	defer mockDB.Close()
+
+	gdb, err := gorm.Open(
+		postgres.New(postgres.Config{Conn: mockDB}),
+		&gorm.Config{SkipDefaultTransaction: true},
+	)
+	if err != nil {
+		t.Fatalf("opening gorm: %v", err)
+	}
+
+	if err := registerMetricsCallbacks(gdb); err != nil {
+		t.Fatalf("registering callbacks: %v", err)
+	}
+
+	before := testutil.ToFloat64(metrics.DBOperations("query", metrics.DBResultSuccess))
+
+	spy.ExpectQuery(`.*`).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(3)))
+
+	var rows []metricsTestRow
+	if err := gdb.Find(&rows).Error; err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+
+	after := testutil.ToFloat64(metrics.DBOperations("query", metrics.DBResultSuccess))
+
+	if after != before+1 {
+		t.Errorf("success count went from %v to %v, wanted one increment", before, after)
+	}
+}

--- a/director/metrics/db.go
+++ b/director/metrics/db.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Result labels for dbOperationsTotal. A database call either succeeded or
+// failed for a reason worth telling apart, because the response to a dead
+// connection is not the response to a constraint violation.
+const (
+	// DBResultSuccess - the operation completed
+	DBResultSuccess = "success"
+	// DBResultNotFound - no row matched. A normal outcome, not a fault
+	DBResultNotFound = "not_found"
+	// DBResultStaleConnection - the connection was dead when it was used.
+	// This is the signature of middleware dropping idle connections
+	DBResultStaleConnection = "stale_connection"
+	// DBResultTimeout - the operation ran out of time
+	DBResultTimeout = "timeout"
+	// DBResultCanceled - the caller gave up before the operation finished
+	DBResultCanceled = "canceled"
+	// DBResultPostgresError - Postgres rejected the statement (constraint
+	// violation, bad SQL). The connection itself was fine
+	DBResultPostgresError = "postgres_error"
+	// DBResultOther - anything not classified above
+	DBResultOther = "other"
+)
+
+// dbOperationsTotal counts gorm operations by kind and outcome
+// operation: create, query, update, delete, row, raw
+// result: see the DBResult constants
+//
+//nolint:gochecknoglobals
+var dbOperationsTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: subsystem,
+		Name:      "db_operations_total",
+		Help:      "Total database operations by kind and outcome.",
+	},
+	[]string{"operation", "result"},
+)
+
+// DBOperations - accessor for dbOperationsTotal
+func DBOperations(operation, result string) prometheus.Counter {
+	return dbOperationsTotal.WithLabelValues(operation, result)
+}
+
+// RegisterDBStats exposes the connection pool's own counters as go_sql_*
+// metrics. These come from database/sql itself and are read at scrape time, so
+// they cost nothing until Prometheus asks. They are what shows whether the pool
+// is recycling connections, and whether callers are queueing for one.
+func RegisterDBStats(pool *sql.DB, dbName string) error {
+	err := prometheus.Register(collectors.NewDBStatsCollector(pool, dbName))
+
+	var alreadyRegistered prometheus.AlreadyRegisteredError
+	if errors.As(err, &alreadyRegistered) {
+		return nil
+	}
+
+	return err
+}


### PR DESCRIPTION
## Summary

Database work in mdmdirector is uninstrumented. There is no metric for whether
operations are succeeding, no way to tell one class of failure from another, and
no visibility into the connection pool, so nothing here can be alerted on or put
on a dashboard.

This adds two things, both behind `-prometheus`:

**`mdmdirector_db_operations_total{operation, result}`** — counted by a gorm
callback on all six processors (`create`, `query`, `update`, `delete`, `row`,
`raw`), so one metric covers every call site rather than needing instrumentation
sprinkled through the code.

The `result` label classifies the outcome by **error identity, not message
text**, so it stays accurate as wording changes upstream:

| result | what it catches |
|---|---|
| `success` | operation completed |
| `not_found` | `gorm.ErrRecordNotFound`. A normal outcome, kept as its own label so it neither inflates the success rate nor fires alerts |
| `stale_connection` | the connection was dead when it was used: `io.ErrUnexpectedEOF`, `driver.ErrBadConn`, `ECONNRESET`, `EPIPE`, `net.ErrClosed` |
| `timeout` | `context.DeadlineExceeded`, `os.ErrDeadlineExceeded`, `pgconn.Timeout` |
| `canceled` | `context.Canceled`. The caller gave up before the operation finished |
| `postgres_error` | `*pgconn.PgError`. Postgres rejected the statement (constraint violation, bad SQL); the connection itself was healthy |
| `other` | anything unclassified |

Separating `postgres_error` from the connection classes is the point of the
split: a unique-constraint violation and a broken socket are both "an error"
today, and they call for completely different responses. Matching on sentinels
with `errors.Is` also survives the wrapping gorm and pgconn add, so a wrapped
failure cannot silently fall through to `other`.

**`go_sql_*` pool metrics** — via the upstream `collectors.NewDBStatsCollector`,
already available in our client_golang. Nine metrics labelled `db_name`, read
from `database/sql` at scrape time, so they cost nothing until Prometheus asks:
`open_connections`, `in_use_connections`, `idle_connections`,
`max_open_connections`, `wait_count_total`, `wait_duration_seconds_total`,
`max_idle_closed_total`, `max_idle_time_closed_total`,
`max_lifetime_closed_total`.