### PR TITLE
feat(ddm): bare DeclarativeManagement activation without conversion

### DIFF
--- a/director/ddm_activate.go
+++ b/director/ddm_activate.go
@@ -1,0 +1,124 @@
+package director
+
+// Bare DDM activation
+//
+// This sends only the DeclarativeManagement command to a device so it enters
+// declarative mode and can use DDM as needed. It does NOT convert any profiles or
+// applications into declarations and it persists no opt-in state: unlike
+// EnableDeviceDDMHandler, future profile/app pushes still follow whatever the global
+// flags / per-device opt-in decide.
+//
+// The device-facing DeclarativeManagement command is emitted by KMFDDM in response to
+// NotifyEnrollment. We first associate the enrollment with its (possibly empty)
+// per-device set so KMFDDM knows the enrollment, then notify to force the command.
+//
+// A single device is activated over HTTP (ActivateDeviceDDMHandler). The whole fleet is
+// activated at startup via the activate-ddm-fleet flag (see ActivateDDMFleet), not over
+// the API.
+
+import (
+	"encoding/json"
+	intErrors "errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/mdmdirector/mdmdirector/ddm"
+	"github.com/mdmdirector/mdmdirector/types"
+)
+
+// activateDDM sends a bare DeclarativeManagement command to a single enrollment.
+// It attaches no declarations and writes no opt-in state.
+func activateDDM(client *ddm.KMFDDMClient, udid string) error {
+	// Associate the enrollment with its per-device set (noNotify=true) so KMFDDM knows
+	// the enrollment exists. The set may hold no declarations - that is fine, nothing is
+	// converted.
+	if err := client.PutEnrollmentSet(udid, udid, true); err != nil {
+		return fmt.Errorf("activateDDM: PUT enrollment-set for %s: %w", udid, err)
+	}
+
+	// Notify to trigger the DDM sync - bypasses the changed-check so the device always
+	// receives a DeclarativeManagement command regardless of prior enrollment state.
+	err := client.NotifyEnrollment(udid)
+	observeDDMNotify(err)
+	if err != nil {
+		return fmt.Errorf("activateDDM: notify enrollment for %s: %w", udid, err)
+	}
+
+	return nil
+}
+
+// activateDevices activates DDM for each device in the slice, skipping empty UDIDs. It
+// returns the count activated and a joined error of any per-device failures. A single
+// failure does not abort the rest.
+func activateDevices(client *ddm.KMFDDMClient, devices []types.Device) (activated int, err error) {
+	var errs []error
+	for i := range devices {
+		device := devices[i]
+		if device.UDID == "" {
+			continue
+		}
+		if aerr := activateDDM(client, device.UDID); aerr != nil {
+			ErrorLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: aerr.Error()})
+			errs = append(errs, aerr)
+			continue
+		}
+		activated++
+		InfoLogger(LogHolder{DeviceUDID: device.UDID, DeviceSerial: device.SerialNumber, Message: "DDM activated for device"})
+	}
+	return activated, intErrors.Join(errs...)
+}
+
+// ActivateDDMFleet sends the DeclarativeManagement command to every device. It returns
+// the number of devices activated and a joined error of any per-device failures. This is
+// invoked at startup when the activate-ddm-fleet flag is set, not over the API.
+func ActivateDDMFleet() (activated int, err error) {
+	client, err := ddm.Client()
+	if err != nil {
+		return 0, err
+	}
+
+	devices, err := GetAllDevices()
+	if err != nil {
+		return 0, fmt.Errorf("ActivateDDMFleet: get all devices: %w", err)
+	}
+
+	return activateDevices(client, devices)
+}
+
+// ActivateDeviceDDMHandler (POST /device/{udid}/ddm/activate) sends a bare
+// DeclarativeManagement command so the device enters declarative mode without converting
+// any profiles or applications.
+func ActivateDeviceDDMHandler(w http.ResponseWriter, r *http.Request) {
+	client, err := ddm.Client()
+	if err != nil {
+		ErrorLogger(LogHolder{Message: "ActivateDeviceDDMHandler: " + err.Error()})
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	udid := mux.Vars(r)["udid"]
+	device, err := GetDevice(udid)
+	if err != nil {
+		http.Error(w, "device not found", http.StatusNotFound)
+		return
+	}
+
+	if err := activateDDM(client, udid); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "ActivateDeviceDDMHandler: " + err.Error()})
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	InfoLogger(LogHolder{DeviceUDID: udid, DeviceSerial: device.SerialNumber, Message: "DDM activated for device"})
+
+	body := map[string]interface{}{
+		"device_udid": udid,
+		"activated":   true,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		ErrorLogger(LogHolder{DeviceUDID: udid, Message: "ActivateDeviceDDMHandler: encode: " + err.Error()})
+	}
+}

--- a/director/ddm_activate_test.go
+++ b/director/ddm_activate_test.go
@@ -1,0 +1,167 @@
+package director
+
+import (
+	"encoding/json"
+	"flag"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/mdmdirector/mdmdirector/ddm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ddmCallCounts records how many times each KMFDDM endpoint the activate path uses was hit
+type ddmCallCounts struct {
+	enrollmentSet atomic.Int32
+	notify        atomic.Int32
+}
+
+// startMockKMFDDM stands up a KMFDDM stand-in and points the global client at it. notifyStatus
+// is the status code returned by POST /v1/notify (204 for success, 5xx to force a failure).
+func startMockKMFDDM(t *testing.T, notifyStatus int) *ddmCallCounts {
+	t.Helper()
+
+	// observeDDMNotify reads the prometheus flag; register it so the lookup never panics
+	if flag.Lookup("prometheus") == nil {
+		flag.Bool("prometheus", false, "Enable prometheus metrics")
+	}
+
+	counts := &ddmCallCounts{}
+	handler := http.NewServeMux()
+	handler.HandleFunc("/v1/enrollment-sets/", func(w http.ResponseWriter, r *http.Request) {
+		counts.enrollmentSet.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	handler.HandleFunc("/v1/notify", func(w http.ResponseWriter, r *http.Request) {
+		counts.notify.Add(1)
+		w.WriteHeader(notifyStatus)
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	ddm.InitClient(server.URL, "test-key")
+	return counts
+}
+
+// --- activateDDM ---
+
+func TestActivateDDM_Success(t *testing.T) {
+	counts := startMockKMFDDM(t, http.StatusNoContent)
+	client, err := ddm.Client()
+	require.NoError(t, err)
+
+	require.NoError(t, activateDDM(client, "udid-1"))
+	assert.Equal(t, int32(1), counts.enrollmentSet.Load())
+	assert.Equal(t, int32(1), counts.notify.Load())
+}
+
+// A non-204 from notify surfaces as an error, and enrollment-set was still attempted first
+func TestActivateDDM_NotifyFails(t *testing.T) {
+	counts := startMockKMFDDM(t, http.StatusInternalServerError)
+	client, err := ddm.Client()
+	require.NoError(t, err)
+
+	err = activateDDM(client, "udid-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "notify enrollment")
+	assert.Equal(t, int32(1), counts.enrollmentSet.Load())
+	assert.Equal(t, int32(1), counts.notify.Load())
+}
+
+// --- activateDevices (fleet loop) ---
+
+func TestActivateDevices_ActivatesEachAndSkipsEmptyUDID(t *testing.T) {
+	counts := startMockKMFDDM(t, http.StatusNoContent)
+	client, err := ddm.Client()
+	require.NoError(t, err)
+
+	devices := testDevices("udid-1", "udid-2")
+	devices = append(devices, testDevices("")...) // empty UDID must be skipped
+
+	activated, err := activateDevices(client, devices)
+	require.NoError(t, err)
+	assert.Equal(t, 2, activated)
+	// One enrollment-set + one notify per real device; the empty UDID made no calls
+	assert.Equal(t, int32(2), counts.enrollmentSet.Load())
+	assert.Equal(t, int32(2), counts.notify.Load())
+}
+
+// A per-device failure is collected but does not abort the rest
+func TestActivateDevices_CollectsErrorsAndContinues(t *testing.T) {
+	counts := startMockKMFDDM(t, http.StatusInternalServerError) // every notify fails
+	client, err := ddm.Client()
+	require.NoError(t, err)
+
+	activated, err := activateDevices(client, testDevices("udid-1", "udid-2"))
+	require.Error(t, err)
+	assert.Equal(t, 0, activated)
+	assert.Len(t, errorMessages(err), 2)
+	assert.Equal(t, int32(2), counts.notify.Load())
+}
+
+// --- ActivateDeviceDDMHandler ---
+
+// serveActivate routes a request through a mux router so {udid} is populated
+func serveActivate(t *testing.T, udid string) *httptest.ResponseRecorder {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/device/"+udid+"/ddm/activate", nil)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/device/{udid}/ddm/activate", ActivateDeviceDDMHandler).Methods(http.MethodPost)
+	router.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestActivateDeviceDDMHandler_Success(t *testing.T) {
+	counts := startMockKMFDDM(t, http.StatusNoContent)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockGetDevice(mockSpy, "udid-1")
+
+	rr := serveActivate(t, "udid-1")
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, "udid-1", body["device_udid"])
+	assert.Equal(t, true, body["activated"])
+	assert.Equal(t, int32(1), counts.notify.Load())
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// An unknown device is a 404 and reaches no KMFDDM endpoint
+func TestActivateDeviceDDMHandler_UnknownDevice(t *testing.T) {
+	counts := startMockKMFDDM(t, http.StatusNoContent)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	expectDeviceNotFound(mockSpy, "missing-udid")
+
+	rr := serveActivate(t, "missing-udid")
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Equal(t, int32(0), counts.notify.Load())
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}
+
+// A KMFDDM failure after the device is found is a 500, not a partial success
+func TestActivateDeviceDDMHandler_NotifyFails(t *testing.T) {
+	startMockKMFDDM(t, http.StatusInternalServerError)
+	mockSpy, cleanup := setupMockDB(t)
+	defer cleanup()
+
+	mockGetDevice(mockSpy, "udid-1")
+
+	rr := serveActivate(t, "udid-1")
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.NotContains(t, rr.Body.String(), "activated")
+	assert.NoError(t, mockSpy.ExpectationsWereMet())
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -150,6 +151,10 @@ var UseDDM bool
 
 // UseDDMPackages controls whether package installation uses DDM instead of InstallApplication commands
 var UseDDMPackages bool
+
+// ActivateDDMFleet, when set, sends a bare DeclarativeManagement command to every device
+// at startup so the whole fleet enters declarative mode. It converts nothing.
+var ActivateDDMFleet bool
 
 // DDMDeclarationPrefix is the organisation-specific reverse-DNS prefix for DDM declaration identifiers
 var DDMDeclarationPrefix string
@@ -437,6 +442,12 @@ func main() {
 		env.Bool("USE_DDM_PACKAGES", false),
 		"Enable DDM package management via KMFDDM instead of InstallApplication commands",
 	)
+	flag.BoolVar(
+		&ActivateDDMFleet,
+		"activate-ddm-fleet",
+		env.Bool("ACTIVATE_DDM_FLEET", false),
+		"At startup, send a bare DeclarativeManagement command to every device so the whole fleet enters declarative mode (converts nothing)",
+	)
 	flag.StringVar(
 		&DDMDeclarationPrefix,
 		"ddm-declaration-prefix",
@@ -603,6 +614,9 @@ func main() {
 	// Per-device DDM opt-in management.
 	r.HandleFunc("/device/{udid}/ddm", utils.BasicAuth(director.EnableDeviceDDMHandler)).Methods("POST")
 	r.HandleFunc("/device/{udid}/ddm", utils.BasicAuth(director.DisableDeviceDDMHandler)).Methods("DELETE")
+	// Bare DDM activation: send only the DeclarativeManagement command for one device (no
+	// conversion, no state). Whole-fleet activation is the activate-ddm-fleet startup flag.
+	r.HandleFunc("/device/{udid}/ddm/activate", utils.BasicAuth(director.ActivateDeviceDDMHandler)).Methods("POST")
 
 	director.InfoLogger(director.LogHolder{Message: "Connecting to database"})
 	if err := db.Open(); err != nil {
@@ -641,6 +655,25 @@ func main() {
 	director.InfoLogger(
 		director.LogHolder{Message: "mdmdirector is running, hold onto your butts..."},
 	)
+
+	// Whole-fleet DDM activation: send a bare DeclarativeManagement command to every
+	// device so it enters declarative mode. Runs in the background so it never blocks
+	// startup, and it converts nothing.
+	if ActivateDDMFleet {
+		if !kmfddmConfigured(MDMServerType, KMFDDMURL, KMFDDMAPIKey, DDMDeclarationPrefix) {
+			log.Warn("activate-ddm-fleet is set but KMFDDM is not fully configured; skipping fleet DDM activation")
+		} else {
+			go func() {
+				director.InfoLogger(director.LogHolder{Message: "Activating DDM for the whole fleet"})
+				activated, ferr := director.ActivateDDMFleet()
+				if ferr != nil {
+					director.ErrorLogger(director.LogHolder{Message: fmt.Sprintf("fleet DDM activation completed with errors (%d activated): %v", activated, ferr)})
+					return
+				}
+				director.InfoLogger(director.LogHolder{Message: fmt.Sprintf("fleet DDM activation complete: %d devices activated", activated)})
+			}()
+		}
+	}
 
 	var QueueFactory = redisq.NewFactory()
 


### PR DESCRIPTION
## Summary

Adds a way to send only the `DeclarativeManagement` command so a device enters declarative mode and can use DDM as needed. It **converts nothing**: no profiles or apps become declarations, and no opt-in state is written, so future pushes keep whatever the global flags / per-device opt-in decide.

- `POST /device/{udid}/ddm/activate` — activate a single device. Returns `{"device_udid": "...", "activated": true}`.
- `--activate-ddm-fleet` (env `ACTIVATE_DDM_FLEET`) — activate the whole fleet at startup, in the background. Converts nothing; skipped with a warning if KMFDDM is not configured.

Under the hood `activateDDM` associates the enrollment with its (possibly empty) per-device set and notifies KMFDDM to emit `DeclarativeManagement`. It never reads the device's profiles/apps, never calls the `...ViaDDM` push paths, and never writes a `DDMOptIn` row — so activation is not a conversion.

## Test Plan

- `go test ./director/` passes (7 new tests in `ddm_activate_test.go`):
  - `activateDDM`: success + notify-failure
  - `activateDevices`: activates each, skips empty UDID, collects per-device errors without aborting
  - `ActivateDeviceDDMHandler`: success (200), unknown device (404, no KMFDDM call), notify failure (500)
- `go vet ./...` clean.

## Notes / follow-up

Not yet verified live: that KMFDDM emits `DeclarativeManagement` on a notify when the enrollment's set is empty. That affects whether the command fires, not whether anything converts. Worth a check against a real KMFDDM before relying on empty-set activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)