### PR TITLE
docs(tools): DDM API helper scripts and docs

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -49,3 +49,48 @@ removes the corresponding declarations from KMFDDM and notifies all devices to s
 ```
 ./tools/delete_shared_install_application https://example.com/app.plist
 ```
+
+## Declarative Device Management (DDM)
+
+These scripts drive the per-device DDM API. All take a device UDID.
+
+There are two distinct ways to put a device on DDM:
+
+- **Activate** (`ddm_activate`) sends only the `DeclarativeManagement` command so the device
+  turns on its declarative engine and can use DDM as needed. It **converts nothing** — no
+  profiles or apps become declarations — and writes no opt-in state.
+- **Enable** (`ddm_enable`) opts the device in and **converts** its existing profiles and
+  apps into declarations via KMFDDM, so subsequent pushes use DDM.
+
+### Activate DDM on a device (no conversion)
+
+```
+./tools/ddm_activate $udid
+```
+
+Whole-fleet activation is not an API call — start the server with `--activate-ddm-fleet`
+(env `ACTIVATE_DDM_FLEET`) to send the bare command to every device at startup.
+
+### Query a device's DDM enabled status
+
+Reports whether the device actually turned on the declarative engine, confirmed from
+KMFDDM status reports: `{device_udid, ddm_enabled, status_count, last_status_at}`.
+
+```
+./tools/ddm_status $udid
+```
+
+### Enable DDM on a device (convert profiles and apps)
+
+```
+./tools/ddm_enable $udid
+```
+
+### Disable DDM on a device
+
+Tears down the device's DDM profile declarations and re-pushes profiles via `InstallProfile`
+commands. Applications already installed via DDM are left in place.
+
+```
+./tools/ddm_disable $udid
+```

--- a/tools/ddm_activate
+++ b/tools/ddm_activate
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Send a bare DeclarativeManagement command to a device so it enters declarative mode and
+# can use DDM as needed. Converts nothing: no profiles or apps become declarations, and no
+# opt-in state is written (future pushes keep whatever the global flags / opt-in decide).
+# Whole-fleet activation is the server's --activate-ddm-fleet startup flag, not an API call.
+# Example:
+#          ./tools/ddm_activate $udid
+#
+source $MDMDIRECTOR_ENV_PATH
+endpoint="device/$1/ddm/activate"
+
+curl -u "mdmdirector:$API_TOKEN" -X POST "$SERVER_URL/$endpoint"

--- a/tools/ddm_disable
+++ b/tools/ddm_disable
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Opt a device out of DDM: tears down its DDM profile declarations in KMFDDM, removes the
+# opt-in, and re-pushes profiles via InstallProfile commands. Applications already
+# installed via DDM are intentionally left in place.
+# Example:
+#          ./tools/ddm_disable $udid
+#
+source $MDMDIRECTOR_ENV_PATH
+endpoint="device/$1/ddm"
+
+curl -u "mdmdirector:$API_TOKEN" -X DELETE "$SERVER_URL/$endpoint"

--- a/tools/ddm_enable
+++ b/tools/ddm_enable
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Opt a device into DDM: converts its profiles and applications into declarations via
+# KMFDDM and switches the device to declarative management. Unlike ddm_activate, this
+# DOES convert existing profiles/apps and persists the opt-in so future pushes use DDM.
+# Example:
+#          ./tools/ddm_enable $udid
+#
+source $MDMDIRECTOR_ENV_PATH
+endpoint="device/$1/ddm"
+
+curl -u "mdmdirector:$API_TOKEN" -X POST "$SERVER_URL/$endpoint"

--- a/tools/ddm_status
+++ b/tools/ddm_status
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Report whether a device has actually turned on the declarative management engine,
+# confirmed from KMFDDM status reports (not just whether mdmdirector sent the command).
+# Returns JSON: {device_udid, ddm_enabled, status_count, last_status_at}.
+# Example:
+#          ./tools/ddm_status $udid
+#
+source $MDMDIRECTOR_ENV_PATH
+endpoint="device/$1/ddm/status"
+
+curl -u "mdmdirector:$API_TOKEN" -X GET "$SERVER_URL/$endpoint"


### PR DESCRIPTION
## Summary

Adds a set of `tools/` helper scripts for the per-device DDM API (matching the existing curl-helper convention) plus a DDM section in `tools/README.md`.

- `ddm_activate $udid` — send only the `DeclarativeManagement` command; converts nothing.
- `ddm_status $udid` — query device-confirmed DDM enabled status from KMFDDM.
- `ddm_enable $udid` — opt in and convert profiles/apps into declarations.
- `ddm_disable $udid` — opt out and re-push profiles via `InstallProfile`.

The README explains the activate-vs-enable distinction and notes that whole-fleet activation is the `--activate-ddm-fleet` startup flag, not an API call.

## Test Plan

- `bash -n` passes on all four scripts.
- Scripts are committed executable (`100755`) and follow the existing `source $MDMDIRECTOR_ENV_PATH` + basic-auth curl pattern.
- Docs-only otherwise; no Go code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)