### PR TITLE
fix(ddm): register the /ddm/status route dropped in the #172 squash

### DIFF
--- a/main.go
+++ b/main.go
@@ -617,6 +617,9 @@ func main() {
 	// Bare DDM activation: send only the DeclarativeManagement command for one device (no
 	// conversion, no state). Whole-fleet activation is the activate-ddm-fleet startup flag.
 	r.HandleFunc("/device/{udid}/ddm/activate", utils.BasicAuth(director.ActivateDeviceDDMHandler)).Methods("POST")
+	// DDM enabled status: reports whether the device turned on the declarative engine,
+	// per KMFDDM status reports (device-confirmed, not just what we sent).
+	r.HandleFunc("/device/{udid}/ddm/status", utils.BasicAuth(director.DeviceDDMStatusHandler)).Methods("GET")
 
 	director.InfoLogger(director.LogHolder{Message: "Connecting to database"})
 	if err := db.Open(); err != nil {


### PR DESCRIPTION
## Summary

`GET /device/{udid}/ddm/status` returns a router-level `404 page not found` on dev, even though `DeviceDDMStatusHandler` and its KMFDDM client call shipped in #172. Cause: the stacked squash-merge of #172 dropped the `main.go` route registration (the merged commit touched only `ddm/client.go`, `director/ddm_status.go`, and the test). The handler is compiled in but never wired to the router.

This re-adds the one route line next to the activate route.

## Test Plan

- `go build ./...` clean.
- Verified against dev via port-forward: activate returns 200, but status returns router 404 on both `0.9.0-0.6.9` and `0.9.0-0.6.10` because the route is unregistered on `nanomdm`. This restores it.
- After a new image build + dev rollout, `GET /device/{udid}/ddm/status` should return the JSON status body instead of 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)