### PR TITLE
[MDMv2] never re-enroll devices that cannot complete ACME (Intel / unknown model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ These flags enable Declarative Device Management via KMFDDM. DDM requires `mdm-s
 - `-acme-cert-issuer string` - Issuer of your ACME certificate. When set, ACME cert expiry will also be checked. Env: `ACME_CERT_ISSUER`
 - `-acme-cert-min-validity int` - Days remaining on ACME certificate before re-enrollment is triggered. (default 180) Env: `ACME_CERT_MIN_VALIDITY`
 
+  Re-enrollment (both the certificate-expiry check and the enrollment-profile signer check) is
+  only ever attempted for devices positively identified as Apple Silicon from their reported
+  `Model`. Intel Macs cannot complete the ACME enrollment profile mdmenroll returns and keep their
+  existing (SCEP) identity untouched; a device whose model is not yet known is treated the same
+  way until its next `DeviceInformation`. Suppressed attempts are counted in
+  `mdmdirector_reenroll_skipped_total{trigger,arch}`.
+
 #### Scheduling and Intervals
 
 - `-push-new-build` - Re-push profiles if the device's build number changes. (default true) Env: `PUSH_NEW_BUILD`

--- a/director/architecture.go
+++ b/director/architecture.go
@@ -1,0 +1,96 @@
+package director
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/mdmdirector/mdmdirector/types"
+)
+
+// architecture is what a device's hardware model proves about its CPU
+type architecture string
+
+const (
+	archSilicon architecture = "silicon"
+	archIntel   architecture = "intel"
+	archUnknown architecture = "unknown"
+)
+
+// siliconThresholds is the first Apple Silicon generation of each legacy model family
+var siliconThresholds = map[string]int{
+	"MacBookAir": 10,
+	"MacBookPro": 17,
+	"Macmini":    9,
+	"iMac":       21,
+	"MacPro":     8, // the last Intel Mac Pro is 7,1
+}
+
+// classifyModel reads an Apple model identifier as reported in DeviceInformation
+// ("MacBookPro16,1", "Mac14,2") and reports what it proves
+func classifyModel(model string) architecture {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return archUnknown
+	}
+
+	// The unified "Mac<gen>,<n>" family (Mac13,1 / Mac14,2 / Mac16,5 ...) is Silicon-only, as
+	// are Apple Virtualization guests, which only run on Apple Silicon hosts.
+	if strings.HasPrefix(model, "VirtualMac") {
+		return archSilicon
+	}
+	if strings.HasPrefix(model, "Mac") && len(model) >= 4 && model[3] >= '1' && model[3] <= '9' {
+		return archSilicon
+	}
+
+	family, generation, ok := splitModel(model)
+	if !ok {
+		return archUnknown
+	}
+
+	// The iMac Pro was Intel-only and was never succeeded.
+	if family == "iMacPro" {
+		return archIntel
+	}
+
+	threshold, known := siliconThresholds[family]
+	if !known {
+		return archUnknown
+	}
+	if generation >= threshold {
+		return archSilicon
+	}
+	return archIntel
+}
+
+// splitModel breaks "MacBookPro16,1" into ("MacBookPro", 16). ok is false when the string is
+// not shaped like a model identifier
+func splitModel(model string) (family string, generation int, ok bool) {
+	base, _, hasComma := strings.Cut(model, ",")
+	if !hasComma {
+		return "", 0, false
+	}
+
+	digits := strings.LastIndexFunc(base, func(r rune) bool { return r < '0' || r > '9' }) + 1
+	if digits == 0 || digits == len(base) {
+		return "", 0, false
+	}
+
+	generation, err := strconv.Atoi(base[digits:])
+	if err != nil {
+		return "", 0, false
+	}
+	return base[:digits], generation, true
+}
+
+// deviceArchitecture classifies a device from the model DeviceInformation reported
+func deviceArchitecture(device types.Device) architecture {
+	return classifyModel(device.Model)
+}
+
+// canReEnrollViaACME reports whether it is safe to push a fresh enrollment profile to this
+// device. Only a positive identification of Apple Silicon qualifies: an unknown model is
+// treated like Intel, which for a Silicon Mac merely defers its ACME renewal until the next
+// DeviceInformation lands, and for an Intel Mac is the only correct answer.
+func canReEnrollViaACME(device types.Device) bool {
+	return deviceArchitecture(device) == archSilicon
+}

--- a/director/architecture_test.go
+++ b/director/architecture_test.go
@@ -1,0 +1,57 @@
+package director
+
+import (
+	"testing"
+
+	"github.com/mdmdirector/mdmdirector/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyModel(t *testing.T) {
+	cases := map[string]architecture{
+		// Unified Silicon family and VMs
+		"Mac13,1":       archSilicon,
+		"Mac14,2":       archSilicon,
+		"Mac16,5":       archSilicon,
+		"VirtualMac2,1": archSilicon,
+
+		// Legacy families at and past their Silicon threshold
+		"MacBookAir10,1": archSilicon,
+		"MacBookPro17,1": archSilicon,
+		"MacBookPro18,3": archSilicon,
+		"Macmini9,1":     archSilicon,
+		"iMac21,1":       archSilicon,
+
+		// Legacy families before their threshold - Intel
+		"MacBookAir9,1":  archIntel,
+		"MacBookPro16,1": archIntel,
+		"MacBookPro15,2": archIntel,
+		"Macmini8,1":     archIntel,
+		"iMac20,1":       archIntel,
+		"iMac19,1":       archIntel,
+		"MacPro7,1":      archIntel,
+		"iMacPro1,1":     archIntel,
+
+		// Not readable - must never be mistaken for Silicon
+		"":                archUnknown,
+		"   ":             archUnknown,
+		"MacBookPro":      archUnknown,
+		"MacBook Pro":     archUnknown,
+		"iPad13,1":        archUnknown,
+		"Macmini":         archUnknown,
+		"UnknownThing1,1": archUnknown,
+		"MacBookPro16":    archUnknown,
+	}
+
+	for model, want := range cases {
+		assert.Equalf(t, want, classifyModel(model), "model %q", model)
+	}
+}
+
+func TestCanReEnrollViaACME(t *testing.T) {
+	assert.True(t, canReEnrollViaACME(types.Device{Model: "MacBookPro18,3"}))
+	assert.True(t, canReEnrollViaACME(types.Device{Model: "Mac14,2"}))
+
+	assert.False(t, canReEnrollViaACME(types.Device{Model: "MacBookPro16,1"}), "Intel must never re-enroll")
+	assert.False(t, canReEnrollViaACME(types.Device{}), "unknown model must fail safe")
+}

--- a/director/certificate.go
+++ b/director/certificate.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/mdmdirector/mdmdirector/db"
+	"github.com/mdmdirector/mdmdirector/director/metrics"
 	"github.com/mdmdirector/mdmdirector/types"
 	"github.com/mdmdirector/mdmdirector/utils"
 	"github.com/pkg/errors"
@@ -156,6 +157,18 @@ func validateEnrollmentCertExpiry(certList []types.CertificateList, device types
 	case found.acme != nil:
 		cert, minValidity, kind = found.acme, utils.AcmeCertMinValidity(), "ACME"
 	case found.scep != nil:
+		// intel devices are not allowed to re-enroll
+		if !canReEnrollViaACME(device) {
+			arch := deviceArchitecture(device)
+			InfoLogger(LogHolder{
+				DeviceSerial: device.SerialNumber,
+				DeviceUDID:   device.UDID,
+				Message:      fmt.Sprintf("SCEP enrollment certificate on a %s device (model %q); ACME re-enrollment is not possible, leaving enrollment alone", arch, device.Model),
+				Metric:       strconv.Itoa(daysUntil(found.scep.NotAfter)),
+			})
+			metrics.ReenrollSkipped("cert_expiry", string(arch)).Inc()
+			return nil
+		}
 		cert, minValidity, kind = found.scep, utils.ScepCertMinValidity(), "SCEP"
 	default:
 		// Neither enrollment certificate is on the device; nothing to renew.

--- a/director/certificate_test.go
+++ b/director/certificate_test.go
@@ -100,7 +100,20 @@ func makeCert(t *testing.T, issuerCN string, validForDays int) types.Certificate
 	return types.CertificateList{Data: der}
 }
 
+// certTestDevice is an Apple Silicon Mac: the population whose SCEP identity is meant to be
+// replaced by ACME.
 func certTestDevice() types.Device {
+	return types.Device{UDID: certTestUDID, SerialNumber: certTestSerial, Model: "MacBookPro18,3"}
+}
+
+// intelTestDevice is an Intel Mac migrated from MicroMDM. It can never complete ACME, so its
+// SCEP identity is the only one it will ever have.
+func intelTestDevice() types.Device {
+	return types.Device{UDID: certTestUDID, SerialNumber: certTestSerial, Model: "MacBookPro16,1"}
+}
+
+// unknownModelTestDevice has not reported DeviceInformation yet.
+func unknownModelTestDevice() types.Device {
 	return types.Device{UDID: certTestUDID, SerialNumber: certTestSerial}
 }
 
@@ -251,4 +264,44 @@ func TestCollectEnrollmentCerts_PrefersLongestLived(t *testing.T) {
 
 	require.NotNil(t, found.acme)
 	assert.Equal(t, 3646, daysUntil(found.acme.NotAfter), "the longer-lived identity should win")
+}
+
+// An Intel Mac holds only a SCEP identity and always will. However far inside
+// scep-cert-min-validity that certificate is, it must not be re-enrolled: mdmenroll would hand
+// back a profile the device cannot complete.
+func TestValidateEnrollmentCertExpiry_ScepOnlyIntelNeverTriggers(t *testing.T) {
+	certList := scepBeforeAcmeCertList(t, 3646)
+	fetches := configureCertFlags(t, certList)
+	scepOnly := certList[:len(certList)-1]
+
+	err := validateEnrollmentCertExpiry(scepOnly, intelTestDevice())
+
+	assert.NoError(t, err)
+	assert.Zero(t, *fetches, "an Intel device must never be sent to mdmenroll")
+}
+
+// Until DeviceInformation has populated the model, the architecture is unknown. Treat that like
+// Intel: for a Silicon Mac it only defers ACME renewal to the next info cycle, for an Intel Mac
+// it is the only safe answer.
+func TestValidateEnrollmentCertExpiry_ScepOnlyUnknownModelDoesNotTrigger(t *testing.T) {
+	certList := scepBeforeAcmeCertList(t, 3646)
+	fetches := configureCertFlags(t, certList)
+	scepOnly := certList[:len(certList)-1]
+
+	err := validateEnrollmentCertExpiry(scepOnly, unknownModelTestDevice())
+
+	assert.NoError(t, err)
+	assert.Zero(t, *fetches, "an unknown model must fail safe and not re-enroll")
+}
+
+// The architecture gate applies to the SCEP branch only: a Silicon Mac whose ACME identity is
+// expiring is a genuine renewal even if, for whatever reason, its model is unreadable.
+func TestValidateEnrollmentCertExpiry_ExpiringAcmeTriggersRegardlessOfModel(t *testing.T) {
+	certList := scepBeforeAcmeCertList(t, 30)
+	fetches := configureCertFlags(t, certList)
+
+	err := validateEnrollmentCertExpiry(certList, unknownModelTestDevice())
+
+	require.Error(t, err)
+	assert.Equal(t, 1, *fetches, "an ACME identity proves the device can do ACME")
 }

--- a/director/enrollment_profile.go
+++ b/director/enrollment_profile.go
@@ -3,11 +3,13 @@ package director
 import (
 	"crypto/x509"
 	"encoding/base64"
+	"fmt"
 	"os"
 	"time"
 
 	"github.com/fullsailor/pkcs7"
 	"github.com/groob/plist"
+	"github.com/mdmdirector/mdmdirector/director/metrics"
 	"github.com/mdmdirector/mdmdirector/types"
 	"github.com/mdmdirector/mdmdirector/utils"
 	"github.com/pkg/errors"
@@ -149,6 +151,19 @@ func ensureCertOnEnrollmentProfile(
 	}
 
 	if !certMatched {
+		// Reinstalling means fetching a fresh enrollment profile from mdmenroll, which only an
+		// Apple Silicon Mac can complete (ACME). An Intel Mac migrated from MicroMDM keeps the
+		// enrollment profile it has, whoever signed it
+		if !canReEnrollViaACME(device) {
+			arch := deviceArchitecture(device)
+			InfoLogger(LogHolder{
+				DeviceUDID:   device.UDID,
+				DeviceSerial: device.SerialNumber,
+				Message:      fmt.Sprintf("Enrollment profile signing certificate does not match local certificate, but the device is %s (model %q) and cannot re-enroll via ACME; leaving enrollment alone", arch, device.Model),
+			})
+			metrics.ReenrollSkipped("signer_mismatch", string(arch)).Inc()
+			return nil
+		}
 		InfoLogger(LogHolder{
 			DeviceUDID:   device.UDID,
 			DeviceSerial: device.SerialNumber,

--- a/director/enrollment_profile_test.go
+++ b/director/enrollment_profile_test.go
@@ -1,6 +1,7 @@
 package director
 
 import (
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"net/http"
@@ -249,4 +250,68 @@ func TestGetEnrollmentProfile_NotFound(t *testing.T) {
 
 	_, found := getEnrollmentProfile(profileLists)
 	assert.False(t, found, "expected no enrollment profile to be found")
+}
+
+// signerMismatchFixture builds a ProfileList carrying an enrollment (com.apple.mdm) profile
+// signed by a certificate that is NOT the local signing certificate, wired to a webhook stub
+// that counts fetches. One fetch is one attempted re-enrollment.
+func signerMismatchFixture(t *testing.T) (profileLists []types.ProfileList, localSigner *x509.Certificate, fetches *int) {
+	t.Helper()
+	registerEnrollmentProfileFlags(t)
+
+	n := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	setFlag(t, "sign", "true")
+	setFlag(t, "enable-reenroll-via-webhook", "true")
+	setFlag(t, "enroll-webhook-url", server.URL)
+	setFlag(t, "enroll-webhook-token", "test-token")
+
+	// Two distinct self-signed certificates: one on the device's profile, one "ours".
+	onDevice := makeCert(t, "Legacy MicroMDM Signer", 365)
+	local := makeCert(t, "MDMDirector Signer", 365)
+	localCert, err := x509.ParseCertificate(local.Data)
+	require.NoError(t, err)
+
+	profileLists = []types.ProfileList{{
+		PayloadIdentifier:  "com.github.micromdm.micromdm.enroll",
+		PayloadContent:     []types.PayloadContentItem{{PayloadType: "com.apple.mdm"}},
+		SignerCertificates: [][]byte{onDevice.Data},
+	}}
+	return profileLists, localCert, &n
+}
+
+// An Intel Mac's enrollment profile was signed by the legacy stack and never will be signed by
+// us. That mismatch must not turn into a re-enrollment: the device cannot complete ACME.
+func TestEnsureCertOnEnrollmentProfile_IntelMismatchDoesNotReinstall(t *testing.T) {
+	profileLists, localCert, fetches := signerMismatchFixture(t)
+
+	err := ensureCertOnEnrollmentProfile(intelTestDevice(), profileLists, localCert)
+
+	assert.NoError(t, err)
+	assert.Zero(t, *fetches, "an Intel device must never be sent to mdmenroll")
+}
+
+// A device whose model is not yet known fails safe the same way.
+func TestEnsureCertOnEnrollmentProfile_UnknownModelMismatchDoesNotReinstall(t *testing.T) {
+	profileLists, localCert, fetches := signerMismatchFixture(t)
+
+	err := ensureCertOnEnrollmentProfile(unknownModelTestDevice(), profileLists, localCert)
+
+	assert.NoError(t, err)
+	assert.Zero(t, *fetches)
+}
+
+// The existing behaviour is preserved for Apple Silicon: a signer mismatch reinstalls.
+func TestEnsureCertOnEnrollmentProfile_SiliconMismatchReinstalls(t *testing.T) {
+	profileLists, localCert, fetches := signerMismatchFixture(t)
+
+	err := ensureCertOnEnrollmentProfile(certTestDevice(), profileLists, localCert)
+
+	require.Error(t, err, "the webhook stub answers 500, so a fired reinstall surfaces here")
+	assert.Equal(t, 1, *fetches)
 }

--- a/director/metrics/metrics.go
+++ b/director/metrics/metrics.go
@@ -367,3 +367,27 @@ func ResultFromError(err error) string {
 	}
 	return "success"
 }
+
+// reenrollSkippedTotal counts re-enrollment attempts that were suppressed because the device
+// cannot complete the enrollment profile mdmenroll would return. An Intel Mac, or one whose
+// model is not yet known, cannot do ACME against stepca, so pushing it a fresh enrollment
+// profile can only fail or re-enroll it into the legacy stack.
+// Labels:
+//   - trigger: "cert_expiry" (validateEnrollmentCertExpiry) or "signer_mismatch"
+//     (ensureCertOnEnrollmentProfile)
+//   - arch:    "intel" or "unknown"
+//
+//nolint:gochecknoglobals
+var reenrollSkippedTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Subsystem: subsystem,
+		Name:      "reenroll_skipped_total",
+		Help:      "Total re-enrollments suppressed because the device architecture cannot complete ACME enrollment, by trigger and architecture.",
+	},
+	[]string{"trigger", "arch"},
+)
+
+// ReenrollSkipped - accessor for reenrollSkippedTotal
+func ReenrollSkipped(trigger, arch string) prometheus.Counter {
+	return reenrollSkippedTotal.WithLabelValues(trigger, arch)
+}


### PR DESCRIPTION
## Summary

Adds support for Intel devices that are migrated to NanoMDM by preventing them from being
re-enrolled to an ACME certificate. Only a device positively identified as Apple Silicon from
its reported `Model` is eligible for re-enrollment; Intel devices keep their existing (SCEP)
identity untouched.

## Why

Both re-enrollment triggers were architecture-agnostic:

- `validateEnrollmentCertExpiry` re-enrolls any device whose SCEP certificate is inside
  `scep-cert-min-validity`. A device that never receives an ACME identity would be re-enrolled
  on every `CertificateList`, indefinitely.
- `ensureCertOnEnrollmentProfile` re-enrolls on an enrollment-profile signer mismatch.

An Intel device cannot complete an ACME enrollment profile, so neither trigger should fire for it.

## Changes

- `director/architecture.go`: classify `Model` as silicon / intel / unknown. Thresholds match
  the first Apple Silicon generation of each legacy model family; the unified `Mac<gen>,<n>`
  family and `VirtualMac` are Silicon.
- `validateEnrollmentCertExpiry`: the SCEP-only branch is skipped unless the device is Silicon.
  The ACME branch is unchanged, so expiring ACME identities still renew.
- `ensureCertOnEnrollmentProfile`: same gate before reinstalling on signer mismatch.
- Unknown model (empty until the first `DeviceInformation` is processed) fails safe and is not
  re-enrolled. For a Silicon device this defers renewal to the next info cycle.
- New counter `mdmdirector_reenroll_skipped_total{trigger,arch}`.
- README updated.
